### PR TITLE
add the Kssd sketch strategy for clust-mst by '--fast' option

### DIFF
--- a/src/MST.cpp
+++ b/src/MST.cpp
@@ -171,6 +171,391 @@ vector<int> getNoiseNode(vector<PairInt> densePairArr, int alpha){
 	return noiseArr;
 }
 
+vector<EdgeInfo> compute_kssd_mst(vector<KssdSketchInfo>& sketches, KssdParameters info, const string folder_path, const string dictFile, const string indexFile,  int start_index, bool isContainment, int threads, int** &denseArr, int denseSpan, uint64_t* &aniArr){
+	// init from the dictFile and indexFile
+	int half_k = info.half_k;
+	int drlevel = info.drlevel;
+	bool use64 = half_k - drlevel > 8 ? true : false;
+	int kmer_size = half_k * 2;
+	robin_hood::unordered_map<uint64_t, vector<uint32_t>> hash_map_arr;
+	uint32_t* sketchSizeArr = NULL;
+	size_t* offset = NULL;
+	uint32_t* indexArr = NULL;
+	//uint64_t* dict;
+	if(use64)
+	{
+		cerr << "-----use hash64 in compute_kssd_mst() " << endl;
+		size_t hash_number;
+		FILE* fp_index = fopen((folder_path+'/'+indexFile).c_str(), "rb");
+		if(!fp_index){
+			cerr << "ERROR: compute_kssd_mst(), cannot open index file: " << indexFile << endl;
+			exit(1);
+		}
+		int read_hash_num = fread(&hash_number, sizeof(size_t), 1, fp_index);
+		uint64_t * hash_arr = new uint64_t[hash_number];
+		uint32_t * hash_size_arr = new uint32_t[hash_number];
+		size_t read_hash_arr = fread(hash_arr, sizeof(uint64_t), hash_number, fp_index);
+		size_t read_hash_size_arr = fread(hash_size_arr, sizeof(uint32_t), hash_number, fp_index);
+		if(read_hash_num != 1 || read_hash_arr != hash_number || read_hash_size_arr != hash_number){
+			cerr << "ERROR: compute_kssd_mst(), error read hash_number, hash_arr, and hash_size_arr" << endl;
+			exit(1);
+		}
+		
+		fclose(fp_index);
+
+		FILE* fp_dict = fopen((folder_path+'/'+dictFile).c_str(), "rb");
+		if(!fp_dict){
+			cerr << "ERROR: compute_kssd_mst(), cannot open dict file: " << dictFile << endl;
+			exit(1);
+		}
+		uint32_t max_hash_size = 1LLU << 24;
+		uint32_t* cur_point = new uint32_t[max_hash_size];
+		for(size_t i = 0; i < hash_number; i++){
+			uint32_t cur_hash_size = hash_size_arr[i];
+			if(cur_hash_size > max_hash_size){
+				max_hash_size = cur_hash_size;
+				cur_point = new uint32_t[max_hash_size];
+			}
+			uint32_t hash_size = fread(cur_point, sizeof(uint32_t), cur_hash_size, fp_dict);
+			if(hash_size != cur_hash_size){
+				cerr << "ERROR: compute_kssd_mst(), the read hash number is not equal to the saved hash number information" << endl;
+				exit(1);
+			}
+			vector<uint32_t> cur_genome_arr(cur_point, cur_point + cur_hash_size);
+			uint64_t cur_hash = hash_arr[i];
+			hash_map_arr.insert({cur_hash, cur_genome_arr});
+		}
+		delete [] cur_point;
+		delete [] hash_arr;
+		delete [] hash_size_arr;
+		fclose(fp_dict);
+	}
+	else{
+		cerr << "-----not use hash64 in compute_kssd_mst() " << endl;
+		size_t hashSize;
+		uint64_t totalIndex;
+		FILE * fp_index = fopen(indexFile.c_str(), "rb");
+		if(!fp_index){
+			cerr << "ERROR: compute_kssd_mst(), cannot open the index sketch file: " << indexFile << endl;
+			exit(1);
+		}
+		int read_hash_size = fread(&hashSize, sizeof(size_t), 1, fp_index);
+		int read_total_index = fread(&totalIndex, sizeof(uint64_t), 1, fp_index);
+		//sketchSizeArr = (uint32_t*)malloc(hashSize * sizeof(uint32_t));
+		sketchSizeArr = new uint32_t[hashSize];
+		size_t read_sketch_size_arr = fread(sketchSizeArr, sizeof(uint32_t), hashSize, fp_index);
+
+		//offset = (size_t*)malloc(hashSize * sizeof(size_t));
+		offset = new size_t[hashSize];
+		uint64_t totalHashNumber = 0;
+		for(size_t i = 0; i < hashSize; i++){
+			totalHashNumber += sketchSizeArr[i];
+			offset[i] = sketchSizeArr[i];
+			if(i > 0) offset[i] += offset[i-1];
+		}
+		if(totalHashNumber != totalIndex){
+			cerr << "ERROR: compute_kssd_mst(), mismatched total hash number" << endl;
+			exit(1);
+		}
+		fclose(fp_index);
+
+		//cerr << "the hashSize is: " << hashSize << endl;
+		//cerr << "totalIndex is: " << totalIndex << endl;
+		//cerr << "totalHashNumber is: " << totalHashNumber << endl;
+		//cerr << "offset[n-1] is: " << offset[hashSize-1] << endl;;
+
+		//indexArr = (uint32_t*)malloc(totalHashNumber * sizeof(uint32_t));
+		indexArr = new uint32_t[totalHashNumber];
+		FILE * fp_dict = fopen(dictFile.c_str(), "rb");
+		if(!fp_dict){
+			cerr << "ERROR: compute_kssd_mst(), cannot open the dictionary sketch file: " << dictFile << endl;
+			exit(1);
+		}
+		size_t read_index_arr = fread(indexArr, sizeof(uint32_t), totalHashNumber, fp_dict);
+		if(read_hash_size != 1 || read_total_index != 1 || read_sketch_size_arr != hashSize || read_index_arr != totalHashNumber){
+			cerr << "ERROR: compute_kssd_mst(), error read hash_size, total_index, sketch_size_arr, index_arr" << endl;
+			exit(1);
+		}
+	}
+
+	//int denseSpan = 10;
+	double step = 1.0 / denseSpan;
+	
+	//double step = threshold / denseSpan;
+	//cerr << "the threshold is: " << threshold << endl;
+	//cerr << "the step is: " << step << endl;
+	int N = sketches.size();
+	denseArr = new int*[denseSpan];
+	int** denseLocalArr = new int*[denseSpan * threads];
+	double distRadius[denseSpan];
+	for(int i = 0; i < denseSpan; i++){
+		distRadius[i] = step * i;
+		denseArr[i] = new int[N];
+		memset(denseArr[i], 0, N * sizeof(int));
+		for(int j = 0; j < threads; j++){
+			denseLocalArr[i * threads + j] = new int[N];
+			memset(denseLocalArr[i*threads+j], 0, N * sizeof(int));
+		}
+	}
+	//for ANI distribution calculation.
+	aniArr = new uint64_t[101];
+	memset(aniArr, 0, 101 * sizeof(uint64_t));
+	uint64_t** threadsANI = new uint64_t*[threads];
+	for(int i = 0; i < threads; i++){
+		threadsANI[i] = new uint64_t[101];
+		memset(threadsANI[i], 0, 101 * sizeof(uint64_t));
+	}
+		
+	// start to generate the sub_mst
+	vector<EdgeInfo> mstArr[threads];
+	int** intersectionArr = new int*[threads];
+	for(int i = 0; i < threads; i++){
+		intersectionArr[i] = new int[sketches.size()];
+	}
+	int subSize = 8;
+	int id = 0;
+	int tailNum = sketches.size() % subSize;
+	//int N = sketches.size();
+	uint64_t totalCompNum = (uint64_t)N * (uint64_t)(N-1)/2;
+	uint64_t percentNum = totalCompNum / 100;
+	cerr << "---the percentNum is: " << percentNum << endl;
+	cerr << "---the start_index is: " << start_index << endl;
+	uint64_t percentId = 0;
+	#pragma omp parallel for num_threads(threads) schedule (dynamic)
+	for(id = 0; id < sketches.size() - tailNum; id+=subSize){
+		int thread_id = omp_get_thread_num();
+		for(int i = id; i < id+subSize; i++){
+			if(use64){
+				for(size_t j = 0; j < sketches[i].hash64_arr.size(); j++){
+					uint64_t hash64 = sketches[i].hash64_arr[j];
+					//if(!(dict[hash64/64] & (0x8000000000000000LLU >> (hash64 % 64))))	continue;
+					if(hash_map_arr.count(hash64) == 0) continue;
+					//for(auto x : hash_map_arr[hash64])
+					for(size_t k = 0; k < hash_map_arr[hash64].size(); k++){
+						size_t cur_index = hash_map_arr[hash64][k];
+						intersectionArr[thread_id][cur_index]++;
+						//cerr << hash64 << '\t' << cur_index << endl;
+					}
+				}
+			}
+			else{
+				for(size_t j = 0; j < sketches[i].hash32_arr.size(); j++){
+					uint32_t hash = sketches[i].hash32_arr[j];
+					if(sketchSizeArr[hash] == 0) continue;
+					size_t start = hash > 0 ? offset[hash-1] : 0;
+					size_t end = offset[hash];
+					for(size_t k = start; k < end; k++){
+						size_t curIndex = indexArr[k];
+						intersectionArr[thread_id][curIndex]++;
+					}
+				}
+			}
+
+			for(int j = max(i+1, start_index); j < sketches.size(); j++){
+				double tmpDist;
+				int common = intersectionArr[thread_id][j];
+				int size0, size1;
+				if(use64){
+					size0 = sketches[i].hash64_arr.size();
+					size1 = sketches[j].hash64_arr.size();
+				}
+				else{
+					size0 = sketches[i].hash32_arr.size();
+					size1 = sketches[j].hash32_arr.size();
+				}
+				if(!isContainment){
+					int denom = size0 + size1 - common;
+					double jaccard;
+					if(size0 == 0 || size1 == 0)
+						jaccard = 0.0;
+					else
+						jaccard = (double)common / denom;
+					double mashD;
+					if(jaccard == 1.0)
+						mashD = 0.0;
+					else if(jaccard == 0.0)
+						mashD = 1.0;
+					else
+						mashD = (double)-1.0 / kmer_size * log((2 * jaccard)/(1.0 + jaccard));
+					tmpDist = mashD;
+				}
+				else{
+					int denom = std::min(size0, size1);
+					double containment;
+					if(size0 == 0 || size1 == 0)
+						containment = 0.0;
+					else
+						containment = (double)common / denom;
+					double AafD;
+					if(containment == 1.0)
+						AafD = 0.0;
+					else if(containment == 0.0)
+						AafD = 1.0;
+					else
+						AafD = (double)-1.0 / kmer_size * log(containment);
+					tmpDist = AafD;
+				}
+
+				for(int t = 0; t < denseSpan; t++){
+					if(tmpDist <= distRadius[t]){
+						denseLocalArr[t * threads + thread_id][i]++;
+						denseLocalArr[t * threads + thread_id][j]++;
+					}
+				}
+				double tmpANI = 1.0 - tmpDist;
+				int ANI = (int)(tmpANI / 0.01);
+				assert(ANI < 101);
+				threadsANI[thread_id][ANI]++;
+					
+				EdgeInfo tmpE{i, j, tmpDist};
+				mstArr[thread_id].push_back(tmpE);
+			}
+		}
+		if(thread_id == 0){
+			uint64_t computedNum = (uint64_t)(N - id) * (uint64_t)id + (uint64_t)id * (uint64_t)id / 2;
+			if(computedNum >= percentId * percentNum){
+				fprintf(stderr, "---finish MST generation %d %\n", percentId);
+				percentId++;
+			}
+		}
+
+		sort(mstArr[thread_id].begin(), mstArr[thread_id].end(), cmpEdge);
+		vector<EdgeInfo> tmpMst = kruskalAlgorithm(mstArr[thread_id], sketches.size());
+		mstArr[thread_id].swap(tmpMst);
+		vector<EdgeInfo>().swap(tmpMst);
+	}
+	cerr << "-----finish the 100 % multiThreads mst generate" << endl;
+
+	for(int i = 0; i < 101; i++){
+		for(int j = 0; j < threads; j++){
+			aniArr[i] += threadsANI[j][i];
+		}
+	}
+	for(int i = 0; i < threads; i++){
+		delete(threadsANI[i]);
+	}
+
+	for(int i = 0; i < denseSpan; i++){
+		for(int j = 0; j < threads; j++){
+			for(int k = 0; k < N; k++){
+				denseArr[i][k] += denseLocalArr[i*threads+j][k];
+			}
+		}
+	}
+	for(int i = 0; i < denseSpan * threads; i++){
+		delete(denseLocalArr[i]);
+	}
+
+	if(tailNum != 0){
+		for(int i = sketches.size()-tailNum; i < sketches.size(); i++){
+			if(use64){
+				for(size_t j = 0; j < sketches[i].hash64_arr.size(); j++){
+					uint64_t hash64 = sketches[i].hash64_arr[j];
+					//if(!(dict[hash64/64] & (0x8000000000000000LLU >> (hash64 % 64))))	continue;
+					if(hash_map_arr.count(hash64) == 0) continue;
+					//for(auto x : hash_map_arr[hash64])
+					for(size_t k = 0; k < hash_map_arr[hash64].size(); k++){
+						size_t cur_index = hash_map_arr[hash64][k];
+						intersectionArr[0][cur_index]++;
+						//cerr << hash64 << '\t' << cur_index << endl;
+					}
+				}
+			}
+			else{
+				for(size_t j = 0; j < sketches[i].hash32_arr.size(); j++){
+					uint32_t hash = sketches[i].hash32_arr[j];
+					if(sketchSizeArr[hash] == 0) continue;
+					size_t start = hash > 0 ? offset[hash-1] : 0;
+					size_t end = offset[hash];
+					for(size_t k = start; k < end; k++){
+						size_t curIndex = indexArr[k];
+						intersectionArr[0][curIndex]++;
+					}
+				}
+			}
+
+			for(int j = i+1; j < sketches.size(); j++){
+				//double tmpDist = 1.0 - minHashes[i].minHash->jaccard(minHashes[j].minHash);
+				double tmpDist;
+				int common = intersectionArr[0][j];
+				int size0, size1;
+				if(use64){
+					size0 = sketches[i].hash64_arr.size();
+					size1 = sketches[j].hash64_arr.size();
+				}
+				else{
+					size0 = sketches[i].hash32_arr.size();
+					size1 = sketches[j].hash32_arr.size();
+				}
+				if(!isContainment){
+					int denom = size0 + size1 - common;
+					double jaccard;
+					if(size0 == 0 || size1 == 0)
+						jaccard = 0.0;
+					else
+						jaccard = (double)common / denom;
+					double mashD;
+					if(jaccard == 1.0)
+						mashD = 0.0;
+					else if(jaccard == 0.0)
+						mashD = 1.0;
+					else
+						mashD = (double)-1.0 / kmer_size * log((2 * jaccard)/(1.0 + jaccard));
+					tmpDist = mashD;
+				}
+				else{
+					int denom = std::min(size0, size1);
+					double containment;
+					if(size0 == 0 || size1 == 0)
+						containment = 0.0;
+					else
+						containment = (double)common / denom;
+					double AafD;
+					if(containment == 1.0)
+						AafD = 0.0;
+					else if(containment == 0.0)
+						AafD = 1.0;
+					else
+						AafD = (double)-1.0 / kmer_size * log(containment);
+					tmpDist = AafD;
+				}
+
+				for(int t = 0; t < denseSpan; t++){
+					if(tmpDist <= distRadius[t]){
+						denseArr[t][i]++;
+						denseArr[t][j]++;
+					}
+				}
+				double tmpANI = 1.0 - tmpDist;
+				int ANI = (int)(tmpANI/0.01);
+				assert(ANI < 101);
+				aniArr[ANI]++;
+
+				EdgeInfo tmpE{i, j, tmpDist};
+				mstArr[0].push_back(tmpE);
+			}
+		}
+		if(mstArr[0].size() != 0){
+			sort(mstArr[0].begin(), mstArr[0].end(), cmpEdge);
+			vector<EdgeInfo> tmpMst = kruskalAlgorithm(mstArr[0], sketches.size());
+			mstArr[0].swap(tmpMst);
+		}
+
+	}
+
+	vector<EdgeInfo> finalGraph;
+	for(int i = 0; i < threads; i++){
+		finalGraph.insert(finalGraph.end(), mstArr[i].begin(), mstArr[i].end());
+		vector<EdgeInfo>().swap(mstArr[i]);
+	}
+
+	sort(finalGraph.begin(), finalGraph.end(), cmpEdge);
+
+	vector<EdgeInfo> mst = kruskalAlgorithm(finalGraph, sketches.size());
+	vector<EdgeInfo>().swap(finalGraph);
+
+	return mst;
+}
 
 
 vector<EdgeInfo> modifyMST(vector<SketchInfo>& sketches, int start_index, int sketch_func_id, int threads, int** &denseArr, int denseSpan, uint64_t* &aniArr){

--- a/src/MST.cpp
+++ b/src/MST.cpp
@@ -186,7 +186,8 @@ vector<EdgeInfo> compute_kssd_mst(vector<KssdSketchInfo>& sketches, KssdParamete
 	{
 		cerr << "-----use hash64 in compute_kssd_mst() " << endl;
 		size_t hash_number;
-		FILE* fp_index = fopen((folder_path+'/'+indexFile).c_str(), "rb");
+		string cur_index_file = folder_path + '/' + indexFile;
+		FILE* fp_index = fopen(cur_index_file.c_str(), "rb");
 		if(!fp_index){
 			cerr << "ERROR: compute_kssd_mst(), cannot open index file: " << indexFile << endl;
 			exit(1);
@@ -203,7 +204,8 @@ vector<EdgeInfo> compute_kssd_mst(vector<KssdSketchInfo>& sketches, KssdParamete
 		
 		fclose(fp_index);
 
-		FILE* fp_dict = fopen((folder_path+'/'+dictFile).c_str(), "rb");
+		string cur_dict_file = folder_path + '/' + dictFile;
+		FILE* fp_dict = fopen(cur_dict_file.c_str(), "rb");
 		if(!fp_dict){
 			cerr << "ERROR: compute_kssd_mst(), cannot open dict file: " << dictFile << endl;
 			exit(1);
@@ -234,7 +236,8 @@ vector<EdgeInfo> compute_kssd_mst(vector<KssdSketchInfo>& sketches, KssdParamete
 		cerr << "-----not use hash64 in compute_kssd_mst() " << endl;
 		size_t hashSize;
 		uint64_t totalIndex;
-		FILE * fp_index = fopen(indexFile.c_str(), "rb");
+		string cur_index_file = folder_path + '/' + indexFile;
+		FILE * fp_index = fopen(cur_index_file.c_str(), "rb");
 		if(!fp_index){
 			cerr << "ERROR: compute_kssd_mst(), cannot open the index sketch file: " << indexFile << endl;
 			exit(1);
@@ -266,7 +269,8 @@ vector<EdgeInfo> compute_kssd_mst(vector<KssdSketchInfo>& sketches, KssdParamete
 
 		//indexArr = (uint32_t*)malloc(totalHashNumber * sizeof(uint32_t));
 		indexArr = new uint32_t[totalHashNumber];
-		FILE * fp_dict = fopen(dictFile.c_str(), "rb");
+		string cur_dict_file = folder_path + '/' + dictFile;
+		FILE * fp_dict = fopen(cur_dict_file.c_str(), "rb");
 		if(!fp_dict){
 			cerr << "ERROR: compute_kssd_mst(), cannot open the dictionary sketch file: " << dictFile << endl;
 			exit(1);

--- a/src/MST.cpp
+++ b/src/MST.cpp
@@ -171,7 +171,7 @@ vector<int> getNoiseNode(vector<PairInt> densePairArr, int alpha){
 	return noiseArr;
 }
 
-vector<EdgeInfo> compute_kssd_mst(vector<KssdSketchInfo>& sketches, KssdParameters info, const string folder_path, const string dictFile, const string indexFile,  int start_index, bool isContainment, int threads, int** &denseArr, int denseSpan, uint64_t* &aniArr){
+vector<EdgeInfo> compute_kssd_mst(vector<KssdSketchInfo>& sketches, KssdParameters info, const string folder_path, int start_index, bool isContainment, int threads, int** &denseArr, int denseSpan, uint64_t* &aniArr){
 	// init from the dictFile and indexFile
 	int half_k = info.half_k;
 	int drlevel = info.drlevel;
@@ -186,10 +186,10 @@ vector<EdgeInfo> compute_kssd_mst(vector<KssdSketchInfo>& sketches, KssdParamete
 	{
 		cerr << "-----use hash64 in compute_kssd_mst() " << endl;
 		size_t hash_number;
-		string cur_index_file = folder_path + '/' + indexFile;
+		string cur_index_file = folder_path + '/' + "kssd.sketch.index";
 		FILE* fp_index = fopen(cur_index_file.c_str(), "rb");
 		if(!fp_index){
-			cerr << "ERROR: compute_kssd_mst(), cannot open index file: " << indexFile << endl;
+			cerr << "ERROR: compute_kssd_mst(), cannot open index file: " << cur_index_file << endl;
 			exit(1);
 		}
 		int read_hash_num = fread(&hash_number, sizeof(size_t), 1, fp_index);
@@ -204,10 +204,10 @@ vector<EdgeInfo> compute_kssd_mst(vector<KssdSketchInfo>& sketches, KssdParamete
 		
 		fclose(fp_index);
 
-		string cur_dict_file = folder_path + '/' + dictFile;
+		string cur_dict_file = folder_path + '/' + "kssd.sketch.dict";
 		FILE* fp_dict = fopen(cur_dict_file.c_str(), "rb");
 		if(!fp_dict){
-			cerr << "ERROR: compute_kssd_mst(), cannot open dict file: " << dictFile << endl;
+			cerr << "ERROR: compute_kssd_mst(), cannot open dict file: " << cur_dict_file << endl;
 			exit(1);
 		}
 		uint32_t max_hash_size = 1LLU << 24;
@@ -236,10 +236,10 @@ vector<EdgeInfo> compute_kssd_mst(vector<KssdSketchInfo>& sketches, KssdParamete
 		cerr << "-----not use hash64 in compute_kssd_mst() " << endl;
 		size_t hashSize;
 		uint64_t totalIndex;
-		string cur_index_file = folder_path + '/' + indexFile;
+		string cur_index_file = folder_path + '/' + "kssd.sketch.index";
 		FILE * fp_index = fopen(cur_index_file.c_str(), "rb");
 		if(!fp_index){
-			cerr << "ERROR: compute_kssd_mst(), cannot open the index sketch file: " << indexFile << endl;
+			cerr << "ERROR: compute_kssd_mst(), cannot open the index sketch file: " << cur_index_file << endl;
 			exit(1);
 		}
 		int read_hash_size = fread(&hashSize, sizeof(size_t), 1, fp_index);
@@ -269,10 +269,10 @@ vector<EdgeInfo> compute_kssd_mst(vector<KssdSketchInfo>& sketches, KssdParamete
 
 		//indexArr = (uint32_t*)malloc(totalHashNumber * sizeof(uint32_t));
 		indexArr = new uint32_t[totalHashNumber];
-		string cur_dict_file = folder_path + '/' + dictFile;
+		string cur_dict_file = folder_path + '/' + "kssd.sketch.dict";
 		FILE * fp_dict = fopen(cur_dict_file.c_str(), "rb");
 		if(!fp_dict){
-			cerr << "ERROR: compute_kssd_mst(), cannot open the dictionary sketch file: " << dictFile << endl;
+			cerr << "ERROR: compute_kssd_mst(), cannot open the dictionary sketch file: " << cur_dict_file << endl;
 			exit(1);
 		}
 		size_t read_index_arr = fread(indexArr, sizeof(uint32_t), totalHashNumber, fp_dict);

--- a/src/MST.cpp
+++ b/src/MST.cpp
@@ -358,7 +358,7 @@ vector<EdgeInfo> compute_kssd_mst(vector<KssdSketchInfo>& sketches, KssdParamete
 				}
 			}
 
-			for(int j = 0; j < start_index; j++){
+			for(int j = 0; j < i; j++){
 				double tmpDist;
 				int common = intersectionArr[thread_id][j];
 				int size0, size1;

--- a/src/MST.cpp
+++ b/src/MST.cpp
@@ -325,6 +325,7 @@ vector<EdgeInfo> compute_kssd_mst(vector<KssdSketchInfo>& sketches, KssdParamete
 	for(id = 0; id < sketches.size() - tailNum; id+=subSize){
 		int thread_id = omp_get_thread_num();
 		for(int i = id; i < id+subSize; i++){
+			memset(intersectionArr[thread_id], 0, sketches.size() * sizeof(int));
 			if(use64){
 				for(size_t j = 0; j < sketches[i].hash64_arr.size(); j++){
 					uint64_t hash64 = sketches[i].hash64_arr[j];

--- a/src/MST.h
+++ b/src/MST.h
@@ -48,7 +48,7 @@ vector<EdgeInfo> append_MST(vector<SketchInfo>& pre_sketches, vector<SketchInfo>
 
 vector<EdgeInfo> modifyMST(vector<SketchInfo>& sketches, int start_index, int sketch_func_id, int threads, int** &denseArr, int denseSpan, uint64_t* &aniArr);
 
-vector<EdgeInfo> compute_kssd_mst(vector<KssdSketchInfo>& sketches, KssdParameters info, const string folder_path, int start_index, bool isContainment, int threads, int** &denseArr, int denseSpan, uint64_t* &aniArr);
+vector<EdgeInfo> compute_kssd_mst(vector<KssdSketchInfo>& sketches, KssdParameters info, const string folder_path, int start_index, bool no_dense, bool isContainment, int threads, int** &denseArr, int denseSpan, uint64_t* &aniArr);
 
 std::vector<EdgeInfo> generateForest(std::vector <EdgeInfo> mst, double threshhold);
 

--- a/src/MST.h
+++ b/src/MST.h
@@ -46,7 +46,7 @@ vector<EdgeInfo> generateMST(vector<SketchInfo>& sketches, string sketchFunc, in
 
 vector<EdgeInfo> append_MST(vector<SketchInfo>& pre_sketches, vector<SketchInfo>& append_sketches, int sketch_func_id, int threads, int ** &denseArr, int denseSpan, uint64_t* &aniArr);
 
-vector<EdgeInfo> modifyMST(vector<SketchInfo>& sketches, int start_index, int sketch_func_id, int threads, int** &denseArr, int denseSpan, uint64_t* &aniArr);
+vector<EdgeInfo> modifyMST(vector<SketchInfo>& sketches, int start_index, int sketch_func_id, int threads, bool no_dense, int** &denseArr, int denseSpan, uint64_t* &aniArr);
 
 vector<EdgeInfo> compute_kssd_mst(vector<KssdSketchInfo>& sketches, KssdParameters info, const string folder_path, int start_index, bool no_dense, bool isContainment, int threads, int** &denseArr, int denseSpan, uint64_t* &aniArr);
 

--- a/src/MST.h
+++ b/src/MST.h
@@ -62,5 +62,6 @@ typedef pair<int, int> PairInt;
 vector<int> getNoiseNode(vector<PairInt> densePairArr, int alpha);
 
 string get_newick_tree(const vector<SketchInfo>& sketches, const vector<EdgeInfo>& mst, bool sketch_by_file);
+string get_kssd_newick_tree(const vector<KssdSketchInfo>& sketches, const vector<EdgeInfo>& mst, bool sketch_by_file);
 
 #endif

--- a/src/MST.h
+++ b/src/MST.h
@@ -48,7 +48,7 @@ vector<EdgeInfo> append_MST(vector<SketchInfo>& pre_sketches, vector<SketchInfo>
 
 vector<EdgeInfo> modifyMST(vector<SketchInfo>& sketches, int start_index, int sketch_func_id, int threads, int** &denseArr, int denseSpan, uint64_t* &aniArr);
 
-vector<EdgeInfo> compute_kssd_mst(vector<KssdSketchInfo>& sketches, KssdParameters info, const string folder_path, const string dictFile, const string indexFile,  int start_index, bool isContainment, int threads, int** &denseArr, int denseSpan, uint64_t* &aniArr);
+vector<EdgeInfo> compute_kssd_mst(vector<KssdSketchInfo>& sketches, KssdParameters info, const string folder_path, int start_index, bool isContainment, int threads, int** &denseArr, int denseSpan, uint64_t* &aniArr);
 
 std::vector<EdgeInfo> generateForest(std::vector <EdgeInfo> mst, double threshhold);
 

--- a/src/MST.h
+++ b/src/MST.h
@@ -48,6 +48,8 @@ vector<EdgeInfo> append_MST(vector<SketchInfo>& pre_sketches, vector<SketchInfo>
 
 vector<EdgeInfo> modifyMST(vector<SketchInfo>& sketches, int start_index, int sketch_func_id, int threads, int** &denseArr, int denseSpan, uint64_t* &aniArr);
 
+vector<EdgeInfo> compute_kssd_mst(vector<KssdSketchInfo>& sketches, KssdParameters info, const string folder_path, const string dictFile, const string indexFile,  int start_index, bool isContainment, int threads, int** &denseArr, int denseSpan, uint64_t* &aniArr);
+
 std::vector<EdgeInfo> generateForest(std::vector <EdgeInfo> mst, double threshhold);
 
 std::vector <std::vector<int> > generateCluster(std::vector<EdgeInfo> forest, int vertices);

--- a/src/MST_IO.cpp
+++ b/src/MST_IO.cpp
@@ -72,6 +72,10 @@ void printKssdResult(vector<vector<int>>& cluster, vector<KssdSketchInfo>& sketc
 {
 	//cerr << "output the result into: " << outputFile << endl;
 	FILE *fp = fopen(outputFile.c_str(), "w");
+	if(!fp){
+		cerr << "Error in printKssdResult(), cannot open file: " << outputFile << endl;
+		exit(1);
+	}
 	
 	if(sketchByFile)
 	{
@@ -106,6 +110,10 @@ void printResult(vector<vector<int>>& cluster, vector<SketchInfo>& sketches, boo
 {
 	//cerr << "output the result into: " << outputFile << endl;
 	FILE *fp = fopen(outputFile.c_str(), "w");
+	if(!fp){
+		cerr << "Error in printResult(), cannot open file: " << outputFile << endl;
+		exit(1);
+	}
 	
 	if(sketchByFile)
 	{
@@ -134,6 +142,25 @@ void printResult(vector<vector<int>>& cluster, vector<SketchInfo>& sketches, boo
 	}//end sketchBySequence
 	fclose(fp);
 
+}
+
+void saveKssdMST(vector<KssdSketchInfo>& sketches, vector<EdgeInfo>& mst, string folderPath, bool sketchByFile){
+	save_kssd_genome_info(sketches, folderPath, "mst", sketchByFile);
+	string file_mst = folderPath + '/' + "edge.mst";
+	FILE* fp_mst = fopen(file_mst.c_str(), "w+");
+	if(!fp_mst){
+		cerr << "ERROR: saveKsdMST(), cannot open the file: " <<  file_mst << endl;
+		exit(1);
+	}
+	size_t mst_size = mst.size();
+	fwrite(&mst_size, sizeof(size_t), 1, fp_mst);
+	for(size_t i = 0; i < mst.size(); i++){
+		fwrite(&mst[i].preNode, sizeof(int), 1, fp_mst);
+		fwrite(&mst[i].sufNode, sizeof(int), 1, fp_mst);
+		fwrite(&mst[i].dist, sizeof(double), 1, fp_mst);
+	}
+	fclose(fp_mst);
+	cerr << "-----save the kssd mst into: " << folderPath << endl;
 }
 
 void saveMST(vector<SketchInfo>& sketches, vector<EdgeInfo>& mst, string folderPath, bool sketchByFile){
@@ -186,6 +213,17 @@ void saveANI(string folderPath, uint64_t* aniArr, int sketch_func_id){
 	fwrite(aniArr, sizeof(uint64_t), 101, fp_ani);
 	fclose(fp_ani);
 	cerr << "-----save the ani file into: " << file_ani << endl;
+}
+
+void print_kssd_newick_tree(const vector<KssdSketchInfo>& sketches, const vector<EdgeInfo>& mst, bool sketch_by_file, string output){
+	string res_newick_tree = get_kssd_newick_tree(sketches, mst, sketch_by_file);
+	FILE* fp_tree = fopen(output.c_str(), "w");
+	if(!fp_tree){
+		cerr << "ERROR: print_newick_tree(), cannot write file: " << output << endl;
+		exit(1);
+	}
+	fprintf(fp_tree, "%s\n", res_newick_tree.c_str());
+	fclose(fp_tree);
 }
 
 void print_newick_tree(const vector<SketchInfo>& sketches, const vector<EdgeInfo>& mst, bool sketch_by_file, string output){

--- a/src/MST_IO.cpp
+++ b/src/MST_IO.cpp
@@ -68,6 +68,40 @@ void loadMST(string folderPath, vector<EdgeInfo>& mst)
 	cerr << "-----read the mst file from " << file_mst << endl;
 }
 
+void printKssdResult(vector<vector<int>>& cluster, vector<KssdSketchInfo>& sketches, bool sketchByFile, string outputFile)
+{
+	//cerr << "output the result into: " << outputFile << endl;
+	FILE *fp = fopen(outputFile.c_str(), "w");
+	
+	if(sketchByFile)
+	{
+		for(int i = 0; i < cluster.size(); i++){
+			fprintf(fp, "the cluster %d is: \n", i);
+			for(int j = 0; j < cluster[i].size(); j++)
+			{
+				int curId = cluster[i][j];
+				fprintf(fp, "\t%5d\t%6d\t%12dnt\t%20s\t%20s\t%s\n", j, curId, sketches[curId].totalSeqLength, sketches[curId].fileName.c_str(),  sketches[curId].fileSeqs[0].name.c_str(), sketches[curId].fileSeqs[0].comment.c_str());
+			}
+			fprintf(fp, "\n");
+		}
+	}//end sketchByFile
+
+	else//sketch by sequence
+	{
+		for(int i = 0; i < cluster.size(); i++){
+			fprintf(fp, "the cluster %d is: \n", i);
+			for(int j = 0; j < cluster[i].size(); j++)
+			{
+				int curId = cluster[i][j];		
+				fprintf(fp, "\t%6d\t%6d\t%12dnt\t%20s\t%s\n", j, curId, sketches[curId].seqInfo.length, sketches[curId].seqInfo.name.c_str(), sketches[curId].seqInfo.comment.c_str());
+			}
+			fprintf(fp, "\n");
+		}
+	}//end sketchBySequence
+	fclose(fp);
+
+}
+
 void printResult(vector<vector<int>>& cluster, vector<SketchInfo>& sketches, bool sketchByFile, string outputFile)
 {
 	//cerr << "output the result into: " << outputFile << endl;

--- a/src/MST_IO.h
+++ b/src/MST_IO.h
@@ -14,6 +14,7 @@ struct ClusterInfo{
 
 void print_newick_tree(const vector<SketchInfo>& sketches, const vector<EdgeInfo>& mst, bool sketch_by_file, string output);
 void printResult(std::vector<std::vector<int>>& clusterOrigin, std::vector<SketchInfo>& sketches, bool sketchByFile, string outputFile);
+void printKssdResult(vector<vector<int>>& cluster, vector<KssdSketchInfo>& sketches, bool sketchByFile, string outputFile);
 
 void loadMST(string folderPath, vector<EdgeInfo>& mst);
 void loadDense(int** &denseArr, string folderPath, int& denseSpan, int& genome_number);

--- a/src/MST_IO.h
+++ b/src/MST_IO.h
@@ -15,12 +15,14 @@ struct ClusterInfo{
 void print_newick_tree(const vector<SketchInfo>& sketches, const vector<EdgeInfo>& mst, bool sketch_by_file, string output);
 void printResult(std::vector<std::vector<int>>& clusterOrigin, std::vector<SketchInfo>& sketches, bool sketchByFile, string outputFile);
 void printKssdResult(vector<vector<int>>& cluster, vector<KssdSketchInfo>& sketches, bool sketchByFile, string outputFile);
+void print_kssd_newick_tree(const vector<KssdSketchInfo>& sketches, const vector<EdgeInfo>& mst, bool sketch_by_file, string output);
 
 void loadMST(string folderPath, vector<EdgeInfo>& mst);
 void loadDense(int** &denseArr, string folderPath, int& denseSpan, int& genome_number);
 void loadANI(string folderPath, uint64_t* &aniArr, int sketch_func_id);
 
 void saveMST(vector<SketchInfo>& sketches, vector<EdgeInfo>& mst, string folderPath, bool sketchByFile);
+void saveKssdMST(vector<KssdSketchInfo>& sketches, vector<EdgeInfo>& mst, string folderPath, bool sketchByFile);
 void saveDense(string folderPath, int** denseArr, int denseSpan, int genome_number);
 void saveANI(string folderPath, uint64_t* aniArr, int sketch_func_id);
 

--- a/src/SketchInfo.cpp
+++ b/src/SketchInfo.cpp
@@ -941,7 +941,7 @@ bool sketchFiles(string inputFile, uint64_t minLen, int kmerSize, int sketchSize
 	return true;
 }
 
-bool sketchFileWithKssd(const string inputFile, const uint64_t minLen, const int kmerSize, const int drlevel, vector<KssdSketchInfo>& sketches, KssdParameters& info, int threads){
+bool sketchFileWithKssd(const string inputFile, const uint64_t minLen, int kmerSize, const int drlevel, vector<KssdSketchInfo>& sketches, KssdParameters& info, int threads){
 	fprintf(stderr, "-----input fileList, sketch by file\n");
 	ifstream ifs(inputFile);
 	if(!ifs){
@@ -967,6 +967,7 @@ bool sketchFileWithKssd(const string inputFile, const uint64_t minLen, const int
 	};
 	// generate the shuffle file.
 	int half_k = (kmerSize + 1) / 2;
+	kmerSize = half_k * 2;
 	bool use64 = half_k - drlevel > 8 ? true : false;
 	int half_subk = 6 - drlevel >= 2 ? 6 : drlevel + 2;
 	int dim_size = 1 << 4 * half_subk;

--- a/src/SketchInfo.cpp
+++ b/src/SketchInfo.cpp
@@ -934,6 +934,7 @@ bool sketchFileWithKssd(const string inputFile, const uint64_t minLen, const int
 }
 
 void transSketches(const vector<KssdSketchInfo>& sketches, const KssdParameters& info, const string folder_path, const string dictFile, const string indexFile, int numThreads){
+	//cerr << "the folder path in transSKetch is: " << folder_path << endl;
 	double t0 = get_sec();
 	int half_k = info.half_k;
 	int drlevel = info.drlevel;
@@ -963,7 +964,8 @@ void transSketches(const vector<KssdSketchInfo>& sketches, const KssdParameters&
 		size_t total_size = 0;
 		uint64_t* hash_arr = (uint64_t*)malloc(hash_number * sizeof(uint64_t));
 		uint32_t* hash_size_arr = (uint32_t*)malloc(hash_number * sizeof(uint32_t));
-		FILE* fp_dict = fopen((folder_path+ '/' + dictFile).c_str(), "w+");
+		string cur_dict_file = folder_path + '/' + dictFile;
+		FILE* fp_dict = fopen((cur_dict_file).c_str(), "w+");
 		if(!fp_dict){
 			cerr << "ERROR: transSketches, cannot open dictFile: " << dictFile << endl;
 			exit(1);
@@ -983,7 +985,8 @@ void transSketches(const vector<KssdSketchInfo>& sketches, const KssdParameters&
 		cerr << "the time of writing dictFile is: " << t2 - t1 << endl;
 		#endif
 
-		FILE* fp_index = fopen((folder_path + '/' + indexFile).c_str(), "w+");
+		string cur_index_file = folder_path + '/' + indexFile;
+		FILE* fp_index = fopen(cur_index_file.c_str(), "w+");
 		if(!fp_index){
 			cerr << "ERROR: transSketches, cannot open indexFile: " << indexFile << endl;
 			exit(1);
@@ -1018,7 +1021,8 @@ void transSketches(const vector<KssdSketchInfo>& sketches, const KssdParameters&
 		cerr << "the time of generate the idx by multiple threads are: " << tt0 - t0 << endl;
 		#endif
 
-		FILE * fp0 = fopen(dictFile.c_str(), "w+");
+		string cur_dict_file = folder_path + '/' + dictFile;
+		FILE * fp0 = fopen(cur_dict_file.c_str(), "w+");
 		uint64_t totalIndex = 0;
 		for(size_t hash = 0; hash < hashSize; hash++){
 			offsetArr[hash] = 0;
@@ -1035,7 +1039,8 @@ void transSketches(const vector<KssdSketchInfo>& sketches, const KssdParameters&
 		cerr << "the time of merge multiple idx into final hashMap is: " << t1 - tt0 << endl;
 		#endif
 
-		FILE * fp1 = fopen(indexFile.c_str(), "w+");
+		string cur_index_file = folder_path + '/' + indexFile;
+		FILE * fp1 = fopen(cur_index_file.c_str(), "w+");
 		fwrite(&hashSize, sizeof(size_t), 1, fp1);
 		fwrite(&totalIndex, sizeof(uint64_t), 1, fp1);
 		fwrite(offsetArr, sizeof(uint32_t), hashSize, fp1);

--- a/src/SketchInfo.cpp
+++ b/src/SketchInfo.cpp
@@ -758,14 +758,14 @@ int * generate_shuffle_dim(int half_subk){
 
 bool sketchFileWithKssd(const string inputFile, const uint64_t minLen, const int kmerSize, const int drlevel, vector<KssdSketchInfo>& sketches, KssdParameters& info, int threads){
 	fprintf(stderr, "-----input fileList, sketch by file\n");
-	fstream fs(inputFile);
-	if(!fs){
+	ifstream ifs(inputFile);
+	if(!ifs){
 		fprintf(stderr, "error open the inputFile: %s\n", inputFile.c_str());
 		return false;
 	}
 	vector<string> fileList;
 	string fileName;
-	while(getline(fs, fileName)){
+	while(getline(ifs, fileName)){
 		fileList.push_back(fileName);
 	}
 
@@ -783,10 +783,10 @@ bool sketchFileWithKssd(const string inputFile, const uint64_t minLen, const int
 	// generate the shuffle file.
 	int half_k = (kmerSize + 1) / 2;
 	bool use64 = half_k - drlevel > 8 ? true : false;
-	int dim_start = 0;
-	int dim_end = 1 << 4 * (half_k - drlevel);
 	int half_subk = 6 - drlevel >= 2 ? 6 : drlevel + 2;
 	int dim_size = 1 << 4 * half_subk;
+	int dim_start = 0;
+	int dim_end = 1 << 4 * (half_subk - drlevel);
 	int* shuffled_dim = generate_shuffle_dim(half_subk);
 	info.half_k = half_k;
 	info.half_subk = half_subk;
@@ -930,6 +930,7 @@ bool sketchFileWithKssd(const string inputFile, const uint64_t minLen, const int
 		kseq_destroy(ks1);
 	}//end for
 
+	return true;
 }
 
 void transSketches(const vector<KssdSketchInfo>& sketches, const KssdParameters& info, const string folder_path, const string dictFile, const string indexFile, int numThreads){

--- a/src/SketchInfo.cpp
+++ b/src/SketchInfo.cpp
@@ -933,7 +933,7 @@ bool sketchFileWithKssd(const string inputFile, const uint64_t minLen, const int
 	return true;
 }
 
-void transSketches(const vector<KssdSketchInfo>& sketches, const KssdParameters& info, const string folder_path, const string dictFile, const string indexFile, int numThreads){
+void transSketches(const vector<KssdSketchInfo>& sketches, const KssdParameters& info, const string folder_path, int numThreads){
 	//cerr << "the folder path in transSKetch is: " << folder_path << endl;
 	double t0 = get_sec();
 	int half_k = info.half_k;
@@ -964,10 +964,10 @@ void transSketches(const vector<KssdSketchInfo>& sketches, const KssdParameters&
 		size_t total_size = 0;
 		uint64_t* hash_arr = (uint64_t*)malloc(hash_number * sizeof(uint64_t));
 		uint32_t* hash_size_arr = (uint32_t*)malloc(hash_number * sizeof(uint32_t));
-		string cur_dict_file = folder_path + '/' + dictFile;
+		string cur_dict_file = folder_path + '/' + "kssd.sketch.dict";
 		FILE* fp_dict = fopen((cur_dict_file).c_str(), "w+");
 		if(!fp_dict){
-			cerr << "ERROR: transSketches, cannot open dictFile: " << dictFile << endl;
+			cerr << "ERROR: transSketches, cannot open dictFile: " << cur_dict_file << endl;
 			exit(1);
 		}
 		size_t cur_id = 0;
@@ -985,10 +985,10 @@ void transSketches(const vector<KssdSketchInfo>& sketches, const KssdParameters&
 		cerr << "the time of writing dictFile is: " << t2 - t1 << endl;
 		#endif
 
-		string cur_index_file = folder_path + '/' + indexFile;
+		string cur_index_file = folder_path + '/' + "kssd.sketch.index";
 		FILE* fp_index = fopen(cur_index_file.c_str(), "w+");
 		if(!fp_index){
-			cerr << "ERROR: transSketches, cannot open indexFile: " << indexFile << endl;
+			cerr << "ERROR: transSketches, cannot open indexFile: " << cur_index_file << endl;
 			exit(1);
 		}
 		fwrite(&hash_number, sizeof(size_t), 1, fp_index);
@@ -1021,7 +1021,7 @@ void transSketches(const vector<KssdSketchInfo>& sketches, const KssdParameters&
 		cerr << "the time of generate the idx by multiple threads are: " << tt0 - t0 << endl;
 		#endif
 
-		string cur_dict_file = folder_path + '/' + dictFile;
+		string cur_dict_file = folder_path + '/' + "kssd.sketch.dict";
 		FILE * fp0 = fopen(cur_dict_file.c_str(), "w+");
 		uint64_t totalIndex = 0;
 		for(size_t hash = 0; hash < hashSize; hash++){
@@ -1039,7 +1039,7 @@ void transSketches(const vector<KssdSketchInfo>& sketches, const KssdParameters&
 		cerr << "the time of merge multiple idx into final hashMap is: " << t1 - tt0 << endl;
 		#endif
 
-		string cur_index_file = folder_path + '/' + indexFile;
+		string cur_index_file = folder_path + '/' + "kssd.sketch.index";
 		FILE * fp1 = fopen(cur_index_file.c_str(), "w+");
 		fwrite(&hashSize, sizeof(size_t), 1, fp1);
 		fwrite(&totalIndex, sizeof(uint64_t), 1, fp1);

--- a/src/SketchInfo.h
+++ b/src/SketchInfo.h
@@ -24,7 +24,7 @@ struct SketchInfo{
 	string fileName;//for sketch files;
 	uint64_t totalSeqLength;
 	Vec_SeqInfo fileSeqs;//for sketch files;
-	SequenceInfo seqInfo;//for sketch squence;
+	SequenceInfo seqInfo;//for sketch sequence;
 	bool isContainment = false;
 	
 	Sketch::MinHash* minHash;
@@ -32,6 +32,25 @@ struct SketchInfo{
 	Sketch::WMinHash* WMinHash;
 	Sketch::HyperLogLog* HLL;
 	Sketch::OrderMinHash * OMH;
+};
+
+struct KssdSketchInfo{
+	int id;
+	string fileName;
+	uint64_t totalSeqLength;
+	Vec_SeqInfo fileSeqs;
+	SequenceInfo seqInfo;
+	bool use64;
+	vector<uint32_t> hash32_arr;
+	vector<uint64_t> hash64_arr;
+};
+
+struct KssdParameters{
+	int id;
+	int half_k;
+	int half_subk;
+	int drlevel;
+	int genomeNumber;
 };
 
 
@@ -42,27 +61,9 @@ void calSize(bool sketchByFile, string inputFile, int threads, uint64_t minLen, 
 bool sketchSequences(string inputFile, int kmerSize, int sketchSize, int minLen, string sketchFunc, bool isContainment, int containCompress, vector<SketchInfo>& sketches, int threads);
 bool sketchFiles(string inputFile, uint64_t minLen, int kmerSize, int sketchSize, string sketchFunc, bool isContainment, int containCompress, vector<SketchInfo>& sketches, int threads);
 bool cmpSketch(SketchInfo s1, SketchInfo s2);
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+//bool sketchFileWithKssd(const string inputFile, const uint64_t minLen, const int kmerSize, const int drlevel, vector<KssdSketchInfo>& sketches, int threads);
+bool sketchFileWithKssd(const string inputFile, const uint64_t minLen, const int kmerSize, const int drlevel, vector<KssdSketchInfo>& sketches, KssdParameters& info, int threads);
+void transSketches(const vector<KssdSketchInfo>& sketches, const KssdParameters& info, const string folder_path, const string dictFile, const string indexFile, int numThreads);
 
 
 

--- a/src/SketchInfo.h
+++ b/src/SketchInfo.h
@@ -62,7 +62,7 @@ bool sketchSequences(string inputFile, int kmerSize, int sketchSize, int minLen,
 bool sketchFiles(string inputFile, uint64_t minLen, int kmerSize, int sketchSize, string sketchFunc, bool isContainment, int containCompress, vector<SketchInfo>& sketches, int threads);
 bool cmpSketch(SketchInfo s1, SketchInfo s2);
 //bool sketchFileWithKssd(const string inputFile, const uint64_t minLen, const int kmerSize, const int drlevel, vector<KssdSketchInfo>& sketches, int threads);
-bool sketchFileWithKssd(const string inputFile, const uint64_t minLen, const int kmerSize, const int drlevel, vector<KssdSketchInfo>& sketches, KssdParameters& info, int threads);
+bool sketchFileWithKssd(const string inputFile, const uint64_t minLen, int kmerSize, const int drlevel, vector<KssdSketchInfo>& sketches, KssdParameters& info, int threads);
 bool sketchSequencesWithKssd(const string inputFile, const int minLen, const int kmerSize, const int drlevel, vector<KssdSketchInfo>& sketches, KssdParameters& info, int threads);
 void transSketches(const vector<KssdSketchInfo>& sketches, const KssdParameters& info, const string folder_path, int numThreads);
 

--- a/src/SketchInfo.h
+++ b/src/SketchInfo.h
@@ -63,6 +63,7 @@ bool sketchFiles(string inputFile, uint64_t minLen, int kmerSize, int sketchSize
 bool cmpSketch(SketchInfo s1, SketchInfo s2);
 //bool sketchFileWithKssd(const string inputFile, const uint64_t minLen, const int kmerSize, const int drlevel, vector<KssdSketchInfo>& sketches, int threads);
 bool sketchFileWithKssd(const string inputFile, const uint64_t minLen, const int kmerSize, const int drlevel, vector<KssdSketchInfo>& sketches, KssdParameters& info, int threads);
+bool sketchSequencesWithKssd(const string inputFile, const int minLen, const int kmerSize, const int drlevel, vector<KssdSketchInfo>& sketches, KssdParameters& info, int threads);
 void transSketches(const vector<KssdSketchInfo>& sketches, const KssdParameters& info, const string folder_path, int numThreads);
 
 

--- a/src/SketchInfo.h
+++ b/src/SketchInfo.h
@@ -63,7 +63,7 @@ bool sketchFiles(string inputFile, uint64_t minLen, int kmerSize, int sketchSize
 bool cmpSketch(SketchInfo s1, SketchInfo s2);
 //bool sketchFileWithKssd(const string inputFile, const uint64_t minLen, const int kmerSize, const int drlevel, vector<KssdSketchInfo>& sketches, int threads);
 bool sketchFileWithKssd(const string inputFile, const uint64_t minLen, const int kmerSize, const int drlevel, vector<KssdSketchInfo>& sketches, KssdParameters& info, int threads);
-void transSketches(const vector<KssdSketchInfo>& sketches, const KssdParameters& info, const string folder_path, const string dictFile, const string indexFile, int numThreads);
+void transSketches(const vector<KssdSketchInfo>& sketches, const KssdParameters& info, const string folder_path, int numThreads);
 
 
 

--- a/src/Sketch_IO.cpp
+++ b/src/Sketch_IO.cpp
@@ -230,6 +230,12 @@ bool loadKssdSketches(string folderPath, int threads, vector<KssdSketchInfo>& sk
 	FILE * fp_hash = fopen(hash_file.c_str(), "r");
 	if(!fp_hash){
 		cerr << "ERROR: loadKssdSketches(), cannot open the file: " << hash_file << endl;
+		string minHash_file = folderPath + '/' + "hash.sketch";
+		FILE * fp_tmp = fopen(minHash_file.c_str(), "r");
+		if(fp_tmp){
+			cerr << "Do you want to load the minHash sketches directory? Try again without '--fast' option" << endl;
+			fclose(fp_tmp);
+		}
 		exit(1);
 	}
 
@@ -280,6 +286,12 @@ bool loadSketches(string folderPath, int threads, vector<SketchInfo>& sketches, 
 	FILE * fp_hash = fopen(hash_file.c_str(), "r");
 	if(!fp_hash){
 		cerr << "ERROR: loadSketches(), cannot open the file: " << hash_file << endl;
+		string kssd_file = folderPath + '/' + "kssd.hash.sketch";
+		FILE * fp_tmp = fopen(kssd_file.c_str(), "r");
+		if(fp_tmp){
+			cerr << "Do you want to load the kssd sketches directory? Try again with '--fast' option" << endl;
+			fclose(fp_tmp);
+		}
 		exit(1);
 	}
 	fread(&sketch_func_id, sizeof(int), 1, fp_hash);
@@ -345,7 +357,13 @@ bool load_kssd_genome_info(string folderPath, string type, vector<KssdSketchInfo
 	string file_genome_info = folderPath + '/' + "kssd.info." + type;
 	FILE* fp_info = fopen(file_genome_info.c_str(), "r");
 	if(!fp_info){
-		cerr << "ERROR: loadMST(), cannot open file: " << file_genome_info << endl;
+		cerr << "ERROR: load_kssd_genome_info(), cannot open file: " << file_genome_info << endl;
+		string minHash_file = folderPath + '/' + "info." + type;
+		FILE * fp_tmp = fopen(minHash_file.c_str(), "r");
+		if(fp_tmp){
+			cerr << "Do you want to load genome info with MinHash sketches? Try again without '--fast' option" << endl;
+			fclose(fp_tmp);
+		}
 		exit(1);
 	}
 	bool sketch_by_file;
@@ -447,7 +465,13 @@ bool load_genome_info(string folderPath, string type, vector<SketchInfo>& sketch
 	string file_genome_info = folderPath + '/' + "info." + type;
 	FILE* fp_info = fopen(file_genome_info.c_str(), "r");
 	if(!fp_info){
-		cerr << "ERROR: loadMST(), cannot open file: " << file_genome_info << endl;
+		cerr << "ERROR: load_genome_info(), cannot open file: " << file_genome_info << endl;
+		string kssd_file = folderPath + '/' + "kssd.info." + type;
+		FILE * fp_tmp = fopen(kssd_file.c_str(), "r");
+		if(fp_tmp){
+			cerr << "Do you want to load genome info with fast sketches? Try again with '--fast' option" << endl;
+			fclose(fp_tmp);
+		}
 		exit(1);
 	}
 	bool sketch_by_file;

--- a/src/Sketch_IO.h
+++ b/src/Sketch_IO.h
@@ -10,4 +10,6 @@ void saveKssdSketches(const vector<KssdSketchInfo>& sketches, const KssdParamete
 
 bool loadSketches(string folderPath, int threads, vector<SketchInfo>& sketches, int& sketch_func_id);
 bool load_genome_info(string folderPath, string type, vector<SketchInfo>& sketches);
+bool load_kssd_genome_info(string folderPath, string type, vector<KssdSketchInfo>& sketches);
+bool loadKssdSketches(string folderPath, int threads, vector<KssdSketchInfo>& sketches, KssdParameters& info);
 #endif

--- a/src/Sketch_IO.h
+++ b/src/Sketch_IO.h
@@ -6,6 +6,7 @@
 void read_sketch_parameters(string folder_path, int& sketch_func_id, int& kmer_size, bool& is_containment, int& contain_compress, int& sketch_size, int& half_k, int& half_subk, int& drlevel);
 void save_genome_info(vector<SketchInfo>& sketches, string folderPath, string type, bool sketchByFile);
 void saveSketches(vector<SketchInfo>& sketches, string folderPath, bool sketchByFile, string sketchFunc, bool isContainment, int containCompress, int sketchSize, int kmerSize);
+void saveKssdSketches(const vector<KssdSketchInfo>& sketches, const KssdParameters info, const string folderPath, bool sketchByFile);
 
 bool loadSketches(string folderPath, int threads, vector<SketchInfo>& sketches, int& sketch_func_id);
 bool load_genome_info(string folderPath, string type, vector<SketchInfo>& sketches);

--- a/src/Sketch_IO.h
+++ b/src/Sketch_IO.h
@@ -5,6 +5,7 @@
 
 void read_sketch_parameters(string folder_path, int& sketch_func_id, int& kmer_size, bool& is_containment, int& contain_compress, int& sketch_size, int& half_k, int& half_subk, int& drlevel);
 void save_genome_info(vector<SketchInfo>& sketches, string folderPath, string type, bool sketchByFile);
+void save_kssd_genome_info(const vector<KssdSketchInfo>& sketches, const string folderPath, const string type, bool sketchByFile);
 void saveSketches(vector<SketchInfo>& sketches, string folderPath, bool sketchByFile, string sketchFunc, bool isContainment, int containCompress, int sketchSize, int kmerSize);
 void saveKssdSketches(const vector<KssdSketchInfo>& sketches, const KssdParameters info, const string folderPath, bool sketchByFile);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -167,7 +167,7 @@ int main(int argc, char * argv[]){
 	}
 
 	if(*option_premsted && !*option_append){
-		clust_from_mst(folder_path, outputFile, is_newick_tree, threshold, threads);
+		clust_from_mst(folder_path, outputFile, is_newick_tree, no_dense, threshold, threads);
 		return 0;
 	}
 	if(*option_append && !*option_presketched && !*option_premsted){
@@ -175,7 +175,7 @@ int main(int argc, char * argv[]){
 		return 1;
 	}
 	if(*option_append && (*option_premsted || *option_presketched)){
-		append_clust_mst(folder_path, inputFile, outputFile, is_newick_tree, sketchByFile, minLen, noSave, threshold, threads);
+		append_clust_mst(folder_path, inputFile, outputFile, is_newick_tree, no_dense, sketchByFile, minLen, noSave, threshold, threads);
 		return 0;
 	}
 //======clust-mst=========================================================================
@@ -193,7 +193,7 @@ int main(int argc, char * argv[]){
 #endif
 	
 	if(*option_presketched && !*option_append){
-		clust_from_sketches(folder_path, outputFile, is_newick_tree, threshold, threads);
+		clust_from_sketches(folder_path, outputFile, is_newick_tree, no_dense, threshold, threads);
 		return 0;
 	}
 
@@ -202,7 +202,7 @@ int main(int argc, char * argv[]){
 	}
 
 	
-	clust_from_genomes(inputFile, outputFile, is_newick_tree, sketchByFile, kmerSize, sketchSize, threshold,sketchFunc, isContainment, containCompress, minLen, folder_path, noSave, threads);
+	clust_from_genomes(inputFile, outputFile, is_newick_tree, sketchByFile, no_dense, kmerSize, sketchSize, threshold,sketchFunc, isContainment, containCompress, minLen, folder_path, noSave, threads);
 
 	return 0;
 }//end main

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -140,6 +140,10 @@ int main(int argc, char * argv[]){
 #ifndef GREEDY_CLUST
 //======clust-mst=========================================================================
 	if(is_fast){
+		if(*option_premsted && !*option_append){
+			clust_from_mst_fast(folder_path, outputFile, is_newick_tree, threshold, threads);
+			return 0;
+		}
 		if(*option_presketched && !*option_append){
 			clust_from_sketch_fast(folder_path, outputFile, is_newick_tree, isContainment, threshold, threads);
 			return 0;
@@ -149,7 +153,7 @@ int main(int argc, char * argv[]){
 			return 1;
 		}
 		if(*option_append && (*option_presketched || *option_premsted)){
-			append_clust_mst_fast(folder_path, inputFile, outputFile, is_newick_tree, sketchByFile, minLen, noSave, threshold, threads);
+			append_clust_mst_fast(folder_path, inputFile, outputFile, is_newick_tree, sketchByFile, isContainment, minLen, noSave, threshold, threads);
 			return 0;
 		}
 		if(!tune_parameters(sketchByFile, isSetKmer, inputFile, threads, minLen, isContainment, isJaccard, kmerSize, threshold, containCompress, sketchSize)){

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,6 +99,7 @@ int main(int argc, char * argv[]){
 	auto option_premsted = app.add_option("--premsted", folder_path, "clustering by the pre-generated mst files rather than genomes for clust-mst");
 	auto flag_newick_tree = app.add_flag("--newick-tree", is_newick_tree, "output the newick tree format file for clust-mst");
 	auto flag_is_fast = app.add_flag("--fast", is_fast, "use the kssd algorithm for sketching and distance computing for clust-mst");
+	auto option_drlevel = app.add_option("--drlevel", drlevel, "set the dimention reduction level for Kssd sketches, default 3 with a dimention reduction of 1/4096");
 #endif
 	auto option_append = app.add_option("--append", inputFile, "append genome file or file list with the pre-generated sketch or MST files");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -136,6 +136,17 @@ int main(int argc, char * argv[]){
 		fprintf(stderr, "-----set threshold:  %d\n", threshold);
 	}
 
+	if(is_fast){
+		if(*option_presketched && !*option_append){
+			clust_from_sketch_fast(folder_path, outputFile, is_newick_tree, isContainment, threshold, threads);
+			return 0;
+		}
+		if(!tune_parameters(sketchByFile, isSetKmer, inputFile, threads, minLen, isContainment, isJaccard, kmerSize, threshold, containCompress, sketchSize)){
+			return 1;
+		}
+		clust_from_genome_fast(inputFile, outputFile, folder_path, is_newick_tree, sketchByFile, isContainment, kmerSize, threshold, drlevel, minLen, noSave, threads);
+		return 0;
+	}
 
 #ifndef GREEDY_CLUST
 //======clust-mst=========================================================================
@@ -174,10 +185,6 @@ int main(int argc, char * argv[]){
 		return 1;
 	}
 
-	if(is_fast){
-		clust_from_genome_fast(inputFile, outputFile, folder_path, is_newick_tree, sketchByFile, isContainment, kmerSize, threshold, drlevel, minLen, noSave, threads);
-		return 0;
-	}
 	
 	clust_from_genomes(inputFile, outputFile, is_newick_tree, sketchByFile, kmerSize, sketchSize, threshold,sketchFunc, isContainment, containCompress, minLen, folder_path, noSave, threads);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -136,9 +136,20 @@ int main(int argc, char * argv[]){
 		fprintf(stderr, "-----set threshold:  %d\n", threshold);
 	}
 
+
+#ifndef GREEDY_CLUST
+//======clust-mst=========================================================================
 	if(is_fast){
 		if(*option_presketched && !*option_append){
 			clust_from_sketch_fast(folder_path, outputFile, is_newick_tree, isContainment, threshold, threads);
+			return 0;
+		}
+		if(*option_append && !*option_premsted && !*option_presketched){
+			cerr << "ERROR: option --append, option --presketched or --premsted needed" << endl;
+			return 1;
+		}
+		if(*option_append && (*option_presketched || *option_premsted)){
+			append_clust_mst_fast(folder_path, inputFile, outputFile, is_newick_tree, sketchByFile, minLen, noSave, threshold, threads);
 			return 0;
 		}
 		if(!tune_parameters(sketchByFile, isSetKmer, inputFile, threads, minLen, isContainment, isJaccard, kmerSize, threshold, containCompress, sketchSize)){
@@ -148,8 +159,6 @@ int main(int argc, char * argv[]){
 		return 0;
 	}
 
-#ifndef GREEDY_CLUST
-//======clust-mst=========================================================================
 	if(*option_premsted && !*option_append){
 		clust_from_mst(folder_path, outputFile, is_newick_tree, threshold, threads);
 		return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,12 +70,14 @@ int main(int argc, char * argv[]){
 	int kmerSize = 21;
 	int sketchSize = 1000;
 	int containCompress = 1000;
+	int drlevel = 3;
 	bool mstLoadSketch = false;
 	string mstSketchFile = "sketch.info";
 	bool isSetKmer = false;
 	uint64_t minLen = 10000;
 	string folder_path;
 	bool is_newick_tree = false;
+	bool is_fast = false;
 
 	bool noSave = false;
 
@@ -96,6 +98,7 @@ int main(int argc, char * argv[]){
 #ifndef GREEDY_CLUST
 	auto option_premsted = app.add_option("--premsted", folder_path, "clustering by the pre-generated mst files rather than genomes for clust-mst");
 	auto flag_newick_tree = app.add_flag("--newick-tree", is_newick_tree, "output the newick tree format file for clust-mst");
+	auto flag_is_fast = app.add_flag("--fast", is_fast, "use the kssd algorithm for sketching and distance computing for clust-mst");
 #endif
 	auto option_append = app.add_option("--append", inputFile, "append genome file or file list with the pre-generated sketch or MST files");
 
@@ -169,6 +172,11 @@ int main(int argc, char * argv[]){
 
 	if(!tune_parameters(sketchByFile, isSetKmer, inputFile, threads, minLen, isContainment, isJaccard, kmerSize, threshold, containCompress, sketchSize)){
 		return 1;
+	}
+
+	if(is_fast){
+		clust_from_genome_fast(inputFile, outputFile, folder_path, is_newick_tree, sketchByFile, isContainment, kmerSize, threshold, drlevel, minLen, noSave, threads);
+		return 0;
 	}
 	
 	clust_from_genomes(inputFile, outputFile, is_newick_tree, sketchByFile, kmerSize, sketchSize, threshold,sketchFunc, isContainment, containCompress, minLen, folder_path, noSave, threads);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,7 +156,7 @@ int main(int argc, char * argv[]){
 			append_clust_mst_fast(folder_path, inputFile, outputFile, is_newick_tree, sketchByFile, isContainment, minLen, noSave, threshold, threads);
 			return 0;
 		}
-		if(!tune_parameters(sketchByFile, isSetKmer, inputFile, threads, minLen, isContainment, isJaccard, kmerSize, threshold, containCompress, sketchSize)){
+		if(!tune_kssd_parameters(sketchByFile, isSetKmer, inputFile, threads, minLen, isContainment, kmerSize, threshold, drlevel)){
 			return 1;
 		}
 		clust_from_genome_fast(inputFile, outputFile, folder_path, is_newick_tree, sketchByFile, isContainment, kmerSize, threshold, drlevel, minLen, noSave, threads);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,7 @@ int main(int argc, char * argv[]){
 	string folder_path;
 	bool is_newick_tree = false;
 	bool is_fast = false;
+	bool no_dense = false;
 
 	bool noSave = false;
 
@@ -100,6 +101,7 @@ int main(int argc, char * argv[]){
 	auto flag_newick_tree = app.add_flag("--newick-tree", is_newick_tree, "output the newick tree format file for clust-mst");
 	auto flag_is_fast = app.add_flag("--fast", is_fast, "use the kssd algorithm for sketching and distance computing for clust-mst");
 	auto option_drlevel = app.add_option("--drlevel", drlevel, "set the dimention reduction level for Kssd sketches, default 3 with a dimention reduction of 1/4096");
+	auto flag_no_dense = app.add_flag("--no-dense", no_dense, "not calculate the density and ANI datas");
 #endif
 	auto option_append = app.add_option("--append", inputFile, "append genome file or file list with the pre-generated sketch or MST files");
 
@@ -142,11 +144,11 @@ int main(int argc, char * argv[]){
 //======clust-mst=========================================================================
 	if(is_fast){
 		if(*option_premsted && !*option_append){
-			clust_from_mst_fast(folder_path, outputFile, is_newick_tree, threshold, threads);
+			clust_from_mst_fast(folder_path, outputFile, is_newick_tree, no_dense, threshold, threads);
 			return 0;
 		}
 		if(*option_presketched && !*option_append){
-			clust_from_sketch_fast(folder_path, outputFile, is_newick_tree, isContainment, threshold, threads);
+			clust_from_sketch_fast(folder_path, outputFile, is_newick_tree, no_dense, isContainment, threshold, threads);
 			return 0;
 		}
 		if(*option_append && !*option_premsted && !*option_presketched){
@@ -154,13 +156,13 @@ int main(int argc, char * argv[]){
 			return 1;
 		}
 		if(*option_append && (*option_presketched || *option_premsted)){
-			append_clust_mst_fast(folder_path, inputFile, outputFile, is_newick_tree, sketchByFile, isContainment, minLen, noSave, threshold, threads);
+			append_clust_mst_fast(folder_path, inputFile, outputFile, is_newick_tree, no_dense, sketchByFile, isContainment, minLen, noSave, threshold, threads);
 			return 0;
 		}
 		if(!tune_kssd_parameters(sketchByFile, isSetKmer, inputFile, threads, minLen, isContainment, kmerSize, threshold, drlevel)){
 			return 1;
 		}
-		clust_from_genome_fast(inputFile, outputFile, folder_path, is_newick_tree, sketchByFile, isContainment, kmerSize, threshold, drlevel, minLen, noSave, threads);
+		clust_from_genome_fast(inputFile, outputFile, folder_path, is_newick_tree, no_dense, sketchByFile, isContainment, kmerSize, threshold, drlevel, minLen, noSave, threads);
 		return 0;
 	}
 

--- a/src/sub_command.cpp
+++ b/src/sub_command.cpp
@@ -179,7 +179,7 @@ void append_clust_mst_fast(string folder_path, string input_file, string output_
 	
 }
 
-void append_clust_mst(string folder_path, string input_file, string output_file, bool is_newick_tree, bool sketch_by_file, int min_len, bool no_save, double threshold, int threads){
+void append_clust_mst(string folder_path, string input_file, string output_file, bool is_newick_tree, bool no_dense, bool sketch_by_file, int min_len, bool no_save, double threshold, int threads){
 	int sketch_func_id_0; 
 	vector<SketchInfo> pre_sketches; 
 	bool pre_sketch_by_file = loadSketches(folder_path, threads, pre_sketches, sketch_func_id_0); 
@@ -235,12 +235,14 @@ void append_clust_mst(string folder_path, string input_file, string output_file,
 	uint64_t* pre_ani_arr;
 	int pre_dense_span;
 	int pre_genome_number;
-	loadDense(pre_dense_arr, folder_path, pre_dense_span, pre_genome_number);
+	if(!no_dense){
+		loadDense(pre_dense_arr, folder_path, pre_dense_span, pre_genome_number);
+	}
 
 	int ** dense_arr;
 	int dense_span = DENSE_SPAN;
 	uint64_t* ani_arr;
-	vector<EdgeInfo> append_mst = modifyMST(final_sketches, pre_sketch_size, sketch_func_id_0, threads, dense_arr, dense_span, ani_arr);
+	vector<EdgeInfo> append_mst = modifyMST(final_sketches, pre_sketch_size, sketch_func_id_0, threads, no_dense, dense_arr, dense_span, ani_arr);
 	vector<EdgeInfo> final_graph;
 	final_graph.insert(final_graph.end(), pre_mst.begin(), pre_mst.end());
 	final_graph.insert(final_graph.end(), append_mst.begin(), append_mst.end());
@@ -261,46 +263,49 @@ void append_clust_mst(string folder_path, string input_file, string output_file,
 	printResult(tmpClust, final_sketches, pre_sketch_by_file, output_file);
 	cerr << "-----write the cluster result into: " << output_file << endl;
 	cerr << "-----the cluster number of: " << output_file << " is: " << tmpClust.size() << endl;
-	
-	loadANI(folder_path, pre_ani_arr, sketch_func_id_0);
-	for(int i = 0; i < 101; i++)
-		ani_arr[i] += pre_ani_arr[i];
-	for(int i = 0; i < pre_dense_span; i++){
-		for(int j = 0; j < pre_genome_number; j++){
-			dense_arr[i][j] += pre_dense_arr[i][j];
-		}
-	}
-
 	if(!no_save){
-		saveANI(new_folder_path, ani_arr, sketch_func_id_0);
-		saveDense(new_folder_path, dense_arr, dense_span, final_sketches.size());
 		saveMST(final_sketches, final_mst, new_folder_path, sketch_by_file);
 	}
-
-
-	int alpha = 2;
-	int denseIndex = threshold / 0.01;
-	vector<int> totalNoiseArr;
-	for(int i = 0; i < tmpClust.size(); i++){
-		if(tmpClust[i].size() == 1) continue;
-		vector<PairInt> curDenseArr;
-		set<int> denseSet;
-		for(int j = 0; j < tmpClust[i].size(); j++){
-			int element = tmpClust[i][j];
-			PairInt p(element, dense_arr[denseIndex][element]);
-			denseSet.insert(dense_arr[denseIndex][element]);
-			curDenseArr.push_back(p);
+	
+	if(!no_dense){
+		loadANI(folder_path, pre_ani_arr, sketch_func_id_0);
+		for(int i = 0; i < 101; i++)
+			ani_arr[i] += pre_ani_arr[i];
+		for(int i = 0; i < pre_dense_span; i++){
+			for(int j = 0; j < pre_genome_number; j++){
+				dense_arr[i][j] += pre_dense_arr[i][j];
+			}
 		}
-		vector<int> curNoiseArr = getNoiseNode(curDenseArr, alpha);
-		totalNoiseArr.insert(totalNoiseArr.end(), curNoiseArr.begin(), curNoiseArr.end());
+		if(!no_save){
+			saveANI(new_folder_path, ani_arr, sketch_func_id_0);
+			saveDense(new_folder_path, dense_arr, dense_span, final_sketches.size());
+		}
+
+		int alpha = 2;
+		int denseIndex = threshold / 0.01;
+		vector<int> totalNoiseArr;
+		for(int i = 0; i < tmpClust.size(); i++){
+			if(tmpClust[i].size() == 1) continue;
+			vector<PairInt> curDenseArr;
+			set<int> denseSet;
+			for(int j = 0; j < tmpClust[i].size(); j++){
+				int element = tmpClust[i][j];
+				PairInt p(element, dense_arr[denseIndex][element]);
+				denseSet.insert(dense_arr[denseIndex][element]);
+				curDenseArr.push_back(p);
+			}
+			vector<int> curNoiseArr = getNoiseNode(curDenseArr, alpha);
+			totalNoiseArr.insert(totalNoiseArr.end(), curNoiseArr.begin(), curNoiseArr.end());
+		}
+		cerr << "-----the total noiseArr size is: " << totalNoiseArr.size() << endl;
+		forest = modifyForest(forest, totalNoiseArr, threads);
+		vector<vector<int>> cluster = generateClusterWithBfs(forest, final_sketches.size());
+		string outputFileNew = output_file + ".removeNoise";
+		printResult(cluster, final_sketches, pre_sketch_by_file, outputFileNew);
+		cerr << "-----write the cluster without noise into: " << outputFileNew << endl;
+		cerr << "-----the cluster number of: " << outputFileNew << " is: " << cluster.size() << endl;
 	}
-	cerr << "-----the total noiseArr size is: " << totalNoiseArr.size() << endl;
-	forest = modifyForest(forest, totalNoiseArr, threads);
-	vector<vector<int>> cluster = generateClusterWithBfs(forest, final_sketches.size());
-	string outputFileNew = output_file + ".removeNoise";
-	printResult(cluster, final_sketches, pre_sketch_by_file, outputFileNew);
-	cerr << "-----write the cluster without noise into: " << outputFileNew << endl;
-	cerr << "-----the cluster number of: " << outputFileNew << " is: " << cluster.size() << endl;
+
 }
 void clust_from_mst_fast(string folder_path, string outputFile, bool is_newick_tree, bool no_dense, double threshold, int threads){
 	vector<KssdSketchInfo> sketches;
@@ -351,7 +356,7 @@ void clust_from_mst_fast(string folder_path, string outputFile, bool is_newick_t
 	}
 }
 
-void clust_from_mst(string folder_path, string outputFile, bool is_newick_tree, double threshold, int threads){
+void clust_from_mst(string folder_path, string outputFile, bool is_newick_tree, bool no_dense, double threshold, int threads){
 	vector<SketchInfo> sketches;
 	vector<EdgeInfo> mst;
 	vector<vector<int>> cluster;
@@ -369,33 +374,36 @@ void clust_from_mst(string folder_path, string outputFile, bool is_newick_tree, 
 	printResult(tmpClust, sketches, sketchByFile, outputFile);
 	cerr << "-----write the cluster result into: " << outputFile << endl;
 	cerr << "-----the cluster number of: " << outputFile << " is: " << tmpClust.size() << endl;
-	int **denseArr;
-	int genome_number = sketches.size();
-	int denseSpan = DENSE_SPAN;
-	loadDense(denseArr, folder_path, denseSpan, genome_number);
-	int alpha = 2;
-	int denseIndex = threshold / 0.01;
-	vector<int> totalNoiseArr;
-	for(int i = 0; i < tmpClust.size(); i++){
-		if(tmpClust[i].size() == 1) continue;
-		vector<PairInt> curDenseArr;
-		set<int> denseSet;
-		for(int j = 0; j < tmpClust[i].size(); j++){
-			int element = tmpClust[i][j];
-			PairInt p(element, denseArr[denseIndex][element]);
-			denseSet.insert(denseArr[denseIndex][element]);
-			curDenseArr.push_back(p);
+
+	if(!no_dense){
+		int **denseArr;
+		int genome_number = sketches.size();
+		int denseSpan = DENSE_SPAN;
+		loadDense(denseArr, folder_path, denseSpan, genome_number);
+		int alpha = 2;
+		int denseIndex = threshold / 0.01;
+		vector<int> totalNoiseArr;
+		for(int i = 0; i < tmpClust.size(); i++){
+			if(tmpClust[i].size() == 1) continue;
+			vector<PairInt> curDenseArr;
+			set<int> denseSet;
+			for(int j = 0; j < tmpClust[i].size(); j++){
+				int element = tmpClust[i][j];
+				PairInt p(element, denseArr[denseIndex][element]);
+				denseSet.insert(denseArr[denseIndex][element]);
+				curDenseArr.push_back(p);
+			}
+			vector<int> curNoiseArr = getNoiseNode(curDenseArr, alpha);
+			totalNoiseArr.insert(totalNoiseArr.end(), curNoiseArr.begin(), curNoiseArr.end());
 		}
-		vector<int> curNoiseArr = getNoiseNode(curDenseArr, alpha);
-		totalNoiseArr.insert(totalNoiseArr.end(), curNoiseArr.begin(), curNoiseArr.end());
+		cerr << "-----the total noiseArr size is: " << totalNoiseArr.size() << endl;
+		forest = modifyForest(forest, totalNoiseArr, threads);
+		cluster = generateClusterWithBfs(forest, sketches.size());
+		string outputFileNew = outputFile + ".removeNoise";
+		printResult(cluster, sketches, sketchByFile, outputFileNew);
+		cerr << "-----write the cluster without noise into: " << outputFileNew << endl;
+		cerr << "-----the cluster number of: " << outputFileNew << " is: " << cluster.size() << endl;
 	}
-	cerr << "-----the total noiseArr size is: " << totalNoiseArr.size() << endl;
-	forest = modifyForest(forest, totalNoiseArr, threads);
-	cluster = generateClusterWithBfs(forest, sketches.size());
-	string outputFileNew = outputFile + ".removeNoise";
-	printResult(cluster, sketches, sketchByFile, outputFileNew);
-	cerr << "-----write the cluster without noise into: " << outputFileNew << endl;
-	cerr << "-----the cluster number of: " << outputFileNew << " is: " << cluster.size() << endl;
 }
 #endif
 
@@ -471,12 +479,11 @@ void compute_kssd_clusters(vector<KssdSketchInfo>& sketches, const KssdParameter
 		printKssdResult(cluster, sketches, sketchByFile, outputFileNew);
 		cerr << "-----write the cluster without noise into: " << outputFileNew << endl;
 		cerr << "-----the cluster number of: " << outputFileNew << " is: " << cluster.size() << endl;
+		double t5 = get_sec();
+		#ifdef Timer
+		cerr << "========time of tuning cluster is: " << t5 - t4 << "========" << endl;
+		#endif
 	}
-	
-	double t5 = get_sec();
-	#ifdef Timer
-	cerr << "========time of tuning cluster is: " << t5 - t4 << "========" << endl;
-	#endif
 //======clust-mst=======================================================================
 }
 
@@ -514,7 +521,7 @@ void compute_kssd_sketches(vector<KssdSketchInfo>& sketches, KssdParameters& inf
 
 }
 
-void clust_from_genomes(string inputFile, string outputFile, bool is_newick_tree, bool sketchByFile, int kmerSize, int sketchSize, double threshold, string sketchFunc, bool isContainment, int containCompress, int minLen, string folder_path, bool noSave, int threads){
+void clust_from_genomes(string inputFile, string outputFile, bool is_newick_tree, bool sketchByFile, bool no_dense, int kmerSize, int sketchSize, double threshold, string sketchFunc, bool isContainment, int containCompress, int minLen, string folder_path, bool noSave, int threads){
 	bool isSave = !noSave;
 	vector<SketchInfo> sketches;
 	int sketch_func_id;
@@ -523,7 +530,7 @@ void clust_from_genomes(string inputFile, string outputFile, bool is_newick_tree
 
 	compute_sketches(sketches, inputFile, folder_path, sketchByFile, minLen, kmerSize, sketchSize, sketchFunc, isContainment, containCompress, isSave, threads);
 
-	compute_clusters(sketches, sketchByFile, outputFile, is_newick_tree, folder_path, sketch_func_id, threshold, isSave, threads);
+	compute_clusters(sketches, sketchByFile, outputFile, is_newick_tree, no_dense, folder_path, sketch_func_id, threshold, isSave, threads);
 }
 
 bool tune_kssd_parameters(bool sketchByFile, bool isSetKmer, string inputFile, int threads, int minLen, bool& isContainment, int& kmerSize, double& threshold, int &drlevel){
@@ -584,9 +591,9 @@ bool tune_kssd_parameters(bool sketchByFile, bool isSetKmer, string inputFile, i
 	cerr << "-----the thread number is: " << threads << endl;
 	cerr << "-----the threshold is: " << threshold << endl;
 	if(isContainment)
-		cerr << "-----use the AAF distance (variable-sketch-size), the sketchSize is approximately in proportion with 1/" << compression << endl;
+		cerr << "-----use the AAF distance, the sketchSize is approximately in proportion with 1/" << compression << endl;
 	else
-		cerr << "-----use the Mash distance (fixed-sketch-size), the sketchSize is about: " << sketchSize << endl;
+		cerr << "-----use the Mash distance, the sketchSize is about: " << sketchSize << endl;
 	#endif
 
 	return true;
@@ -744,7 +751,7 @@ void clust_from_sketch_fast(string folder_path, string outputFile, bool is_newic
 	#endif
 }
 
-void clust_from_sketches(string folder_path, string outputFile, bool is_newick_tree, double threshold, int threads){
+void clust_from_sketches(string folder_path, string outputFile, bool is_newick_tree, bool no_dense, double threshold, int threads){
 	vector<SketchInfo> sketches;
 	vector<vector<int>> cluster;
 	int sketch_func_id;
@@ -779,7 +786,7 @@ void clust_from_sketches(string folder_path, string outputFile, bool is_newick_t
 	int** denseArr;
 	uint64_t* aniArr; //= new uint64_t[101];
 	int denseSpan = DENSE_SPAN;
-	vector<EdgeInfo> mst = modifyMST(sketches, 0, sketch_func_id, threads, denseArr, denseSpan, aniArr);
+	vector<EdgeInfo> mst = modifyMST(sketches, 0, sketch_func_id, threads, no_dense, denseArr, denseSpan, aniArr);
 	double time2 = get_sec();
 	#ifdef Timer
 	cerr << "========time of generateMST is: " << time2 - time1 << "========" << endl;
@@ -795,29 +802,31 @@ void clust_from_sketches(string folder_path, string outputFile, bool is_newick_t
 	cerr << "-----write the cluster result into: " << outputFile << endl;
 	cerr << "-----the cluster number of: " << outputFile << " is: " << tmpClust.size() << endl;
 
-	int alpha = 2;
-	int denseIndex = threshold / 0.01;
-	vector<int> totalNoiseArr;
-	for(int i = 0; i < tmpClust.size(); i++){
-		if(tmpClust[i].size() == 1) continue;
-		vector<PairInt> curDenseArr;
-		set<int> denseSet;
-		for(int j = 0; j < tmpClust[i].size(); j++){
-			int element = tmpClust[i][j];
-			PairInt p(element, denseArr[denseIndex][element]);
-			denseSet.insert(denseArr[denseIndex][element]);
-			curDenseArr.push_back(p);
+	if(!no_dense){
+		int alpha = 2;
+		int denseIndex = threshold / 0.01;
+		vector<int> totalNoiseArr;
+		for(int i = 0; i < tmpClust.size(); i++){
+			if(tmpClust[i].size() == 1) continue;
+			vector<PairInt> curDenseArr;
+			set<int> denseSet;
+			for(int j = 0; j < tmpClust[i].size(); j++){
+				int element = tmpClust[i][j];
+				PairInt p(element, denseArr[denseIndex][element]);
+				denseSet.insert(denseArr[denseIndex][element]);
+				curDenseArr.push_back(p);
+			}
+			vector<int> curNoiseArr = getNoiseNode(curDenseArr, alpha);
+			totalNoiseArr.insert(totalNoiseArr.end(), curNoiseArr.begin(), curNoiseArr.end());
 		}
-		vector<int> curNoiseArr = getNoiseNode(curDenseArr, alpha);
-		totalNoiseArr.insert(totalNoiseArr.end(), curNoiseArr.begin(), curNoiseArr.end());
+		cerr << "-----the total noiseArr size is: " << totalNoiseArr.size() << endl;
+		forest = modifyForest(forest, totalNoiseArr, threads);
+		cluster = generateClusterWithBfs(forest, sketches.size());
+		string outputFileNew = outputFile + ".removeNoise";
+		printResult(cluster, sketches, sketchByFile, outputFileNew);
+		cerr << "-----write the cluster without noise into: " << outputFileNew << endl;
+		cerr << "-----the cluster number of: " << outputFileNew << " is: " << cluster.size() << endl;
 	}
-	cerr << "-----the total noiseArr size is: " << totalNoiseArr.size() << endl;
-	forest = modifyForest(forest, totalNoiseArr, threads);
-	cluster = generateClusterWithBfs(forest, sketches.size());
-	string outputFileNew = outputFile + ".removeNoise";
-	printResult(cluster, sketches, sketchByFile, outputFileNew);
-	cerr << "-----write the cluster without noise into: " << outputFileNew << endl;
-	cerr << "-----the cluster number of: " << outputFileNew << " is: " << cluster.size() << endl;
 	double time3 = get_sec();
 	#ifdef Timer
 	cerr << "========time of generator forest and cluster is: " << time3 - time2 << "========" << endl;
@@ -857,7 +866,7 @@ void compute_sketches(vector<SketchInfo>& sketches, string inputFile, string& fo
 	}
 }
 
-void compute_clusters(vector<SketchInfo>& sketches, bool sketchByFile, string outputFile, bool is_newick_tree, string folder_path, int sketch_func_id, double threshold, bool isSave, int threads){
+void compute_clusters(vector<SketchInfo>& sketches, bool sketchByFile, string outputFile, bool is_newick_tree, bool no_dense, string folder_path, int sketch_func_id, double threshold, bool isSave, int threads){
 	vector<vector<int>> cluster;
 	double t2 = get_sec();
 #ifdef GREEDY_CLUST
@@ -876,14 +885,12 @@ void compute_clusters(vector<SketchInfo>& sketches, bool sketchByFile, string ou
 	int **denseArr;
 	uint64_t* aniArr; //= new uint64_t[101];
 	int denseSpan = DENSE_SPAN;
-	vector<EdgeInfo> mst = modifyMST(sketches, 0, sketch_func_id, threads, denseArr, denseSpan, aniArr);
+	vector<EdgeInfo> mst = modifyMST(sketches, 0, sketch_func_id, threads, no_dense, denseArr, denseSpan, aniArr);
 	double t3 = get_sec();
 	#ifdef Timer
 	cerr << "========time of generateMST is: " << t3 - t2 << "========" << endl;
 	#endif
 	if(isSave){
-		saveANI(folder_path, aniArr, sketch_func_id);
-		saveDense(folder_path, denseArr, denseSpan, sketches.size());
 		saveMST(sketches, mst, folder_path, sketchByFile);
 	}
 	double t4 = get_sec();
@@ -898,47 +905,47 @@ void compute_clusters(vector<SketchInfo>& sketches, bool sketchByFile, string ou
 		cerr << "-----write the newick tree into: " << output_newick_file << endl;
 	}
 
-
-//	for(int i = 0; i < denseSpan; i++){
-//		for(int j = 0; j < sketches.size(); j++){
-//			cout << denseArr[i][j] << endl;
-//		}
-//	}
-	
 	vector<EdgeInfo> forest = generateForest(mst, threshold);
 	vector<vector<int>> tmpClust = generateClusterWithBfs(forest, sketches.size());
 	printResult(tmpClust, sketches, sketchByFile, outputFile);
 	cerr << "-----write the cluster result into: " << outputFile << endl;
 	cerr << "-----the cluster number of: " << outputFile << " is: " << tmpClust.size() << endl;
+
 	//tune cluster by noise cluster
-	int alpha = 2;
-	int denseIndex = threshold / 0.01;
-	vector<int> totalNoiseArr;
-	for(int i = 0; i < tmpClust.size(); i++){
-		if(tmpClust[i].size() == 1) continue;
-		vector<PairInt> curDenseArr;
-		set<int> denseSet;
-		for(int j = 0; j < tmpClust[i].size(); j++){
-			int element = tmpClust[i][j];
-			PairInt p(element, denseArr[denseIndex][element]);
-			denseSet.insert(denseArr[denseIndex][element]);
-			curDenseArr.push_back(p);
+	if(!no_dense){
+		if(isSave){
+			saveANI(folder_path, aniArr, sketch_func_id);
+			saveDense(folder_path, denseArr, denseSpan, sketches.size());
 		}
-		vector<int> curNoiseArr = getNoiseNode(curDenseArr, alpha);
-		totalNoiseArr.insert(totalNoiseArr.end(), curNoiseArr.begin(), curNoiseArr.end());
+		int alpha = 2;
+		int denseIndex = threshold / 0.01;
+		vector<int> totalNoiseArr;
+		for(int i = 0; i < tmpClust.size(); i++){
+			if(tmpClust[i].size() == 1) continue;
+			vector<PairInt> curDenseArr;
+			set<int> denseSet;
+			for(int j = 0; j < tmpClust[i].size(); j++){
+				int element = tmpClust[i][j];
+				PairInt p(element, denseArr[denseIndex][element]);
+				denseSet.insert(denseArr[denseIndex][element]);
+				curDenseArr.push_back(p);
+			}
+			vector<int> curNoiseArr = getNoiseNode(curDenseArr, alpha);
+			totalNoiseArr.insert(totalNoiseArr.end(), curNoiseArr.begin(), curNoiseArr.end());
+		}
+		cerr << "-----the total noiseArr size is: " << totalNoiseArr.size() << endl;
+		forest = modifyForest(forest, totalNoiseArr, threads);
+		cluster = generateClusterWithBfs(forest, sketches.size());
+		string outputFileNew = outputFile + ".removeNoise";
+		printResult(cluster, sketches, sketchByFile, outputFileNew);
+		cerr << "-----write the cluster without noise into: " << outputFileNew << endl;
+		cerr << "-----the cluster number of: " << outputFileNew << " is: " << cluster.size() << endl;
+		double t5 = get_sec();
+		#ifdef Timer
+		cerr << "========time of tuning cluster is: " << t5 - t4 << "========" << endl;
+		#endif
 	}
-	cerr << "-----the total noiseArr size is: " << totalNoiseArr.size() << endl;
-	forest = modifyForest(forest, totalNoiseArr, threads);
-	cluster = generateClusterWithBfs(forest, sketches.size());
-	string outputFileNew = outputFile + ".removeNoise";
-	printResult(cluster, sketches, sketchByFile, outputFileNew);
-	cerr << "-----write the cluster without noise into: " << outputFileNew << endl;
-	cerr << "-----the cluster number of: " << outputFileNew << " is: " << cluster.size() << endl;
 	
-	double t5 = get_sec();
-	#ifdef Timer
-	cerr << "========time of tuning cluster is: " << t5 - t4 << "========" << endl;
-	#endif
 //======clust-mst=======================================================================
 #endif//endif GREEDY_CLUST
 }

--- a/src/sub_command.cpp
+++ b/src/sub_command.cpp
@@ -242,8 +242,8 @@ void clust_from_genome_fast(const string inputFile, string outputFile, string fo
 	vector<KssdSketchInfo> sketches;
 	KssdParameters info;
 	compute_kssd_sketches(sketches, info, isSave, inputFile, folder_path, sketchByFile, minLen, kmerSize, drlevel, threads);
-	string dictFile = inputFile + "sketch.dict";
-	string indexFile = inputFile + "sketch.index";
+	string dictFile = inputFile + ".sketch.dict";
+	string indexFile = inputFile + ".sketch.index";
 	transSketches(sketches, info, folder_path, dictFile, indexFile, threads);
 	compute_kssd_clusters(sketches, info, sketchByFile, isContainment, folder_path, dictFile, indexFile, outputFile, is_newick_tree, threshold, isSave, threads);
 
@@ -346,7 +346,7 @@ void compute_kssd_sketches(vector<KssdSketchInfo>& sketches, KssdParameters& inf
 		}
 	}//end sketch by sequence
 	else{
-		cerr << "The sketch by sequences are TODO implemented." << endl;
+		cerr << "TODO: The sketch by sequences are TODO implemented." << endl;
 		exit(0);
 	}//end sketch by file
 	cerr << "-----the size of sketches (number of genomes or sequences) is: " << sketches.size() << endl;
@@ -358,8 +358,7 @@ void compute_kssd_sketches(vector<KssdSketchInfo>& sketches, KssdParameters& inf
 	if(isSave){
 		string command = "mkdir -p " + folder_path;
 		system(command.c_str());
-		cerr << "The saving of kssd sketches are TODO implement" << endl;
-		//saveSketches(sketches, folder_path, sketchByFile, sketchFunc, isContainment, containCompress, sketchSize, kmerSize);
+		saveKssdSketches(sketches, info, folder_path, sketchByFile);
 		double t2 = get_sec();
 		#ifdef Timer
 		cerr << "========time of saveSketches is: " << t2 - t1 << "========" << endl;

--- a/src/sub_command.cpp
+++ b/src/sub_command.cpp
@@ -409,7 +409,7 @@ void clust_from_genome_fast(const string inputFile, string outputFile, string fo
 
 }
 
-void compute_kssd_clusters(vector<KssdSketchInfo>& sketches, const KssdParameters info, bool no_dense, bool sketchByFile, bool isContainment, const string folder_path, string outputFile, bool is_newick_tree, double threshold, bool isSave, int threads){
+void compute_kssd_clusters(vector<KssdSketchInfo>& sketches, const KssdParameters info, bool sketchByFile, bool no_dense, bool isContainment, const string folder_path, string outputFile, bool is_newick_tree, double threshold, bool isSave, int threads){
 	vector<vector<int>> cluster;
 	double t2 = get_sec();
 //======clust-mst=======================================================================

--- a/src/sub_command.cpp
+++ b/src/sub_command.cpp
@@ -326,13 +326,16 @@ void compute_kssd_sketches(vector<KssdSketchInfo>& sketches, KssdParameters& inf
 	if(sketchByFile){
 		//if(!sketchFiles(inputFile, minLen, kmerSize, sketchSize, sketchFunc, isContainment, containCompress, sketches, threads)){
 		if(!sketchFileWithKssd(inputFile, minLen, kmerSize, drlevel, sketches, info, threads)){
-			cerr << "ERROR: generate_sketches(), cannot finish the sketch generation by genome files" << endl;
+			cerr << "ERROR: sketchFileWithKssd(), cannot finish the sketch generation by genome files" << endl;
 			exit(1);
 		}
 	}//end sketch by sequence
 	else{
-		cerr << "TODO: The sketch by sequences are TODO implemented." << endl;
-		exit(0);
+		cerr << "use the sketch seuqnce with kssd " << endl;
+		if(!sketchSequencesWithKssd(inputFile, minLen, kmerSize, drlevel, sketches, info, threads)){
+			cerr << "ERROR: sketchSequencesWithKssd (), cannot finish the sketch generation by genome sequences" << endl;
+			exit(1);
+		}
 	}//end sketch by file
 	cerr << "-----the size of sketches (number of genomes or sequences) is: " << sketches.size() << endl;
 	double t1 = get_sec();

--- a/src/sub_command.h
+++ b/src/sub_command.h
@@ -25,3 +25,8 @@ void append_clust_mst(string folder_path, string input_file, string output_file,
 
 void append_clust_greedy(string folder_path, string input_file, string output_file, bool sketch_by_file, int min_len, bool no_save, double threshold, int threads);
 
+void compute_kssd_sketches(vector<KssdSketchInfo>& sketches, KssdParameters& info, bool isSave, const string inputFile, string& folder_path, bool sketchByFile, const int minLen, const int kmerSize, const int drlevel, int threads);
+void compute_kssd_clusters(vector<KssdSketchInfo>& sketches, const KssdParameters info, bool sketchByFile, bool isContainment, const string folder_path, const string dictFile, const string indexFile, string outputFile, bool is_newick_tree, double threshold, bool isSave, int threads);
+
+void clust_from_genome_fast(const string inputFile, string outputFile, string folder_path, bool is_newick_tree, bool sketchByFile, bool isContainment, const int kmerSize, const double threshold, const int drlevel, const int minLen, bool noSave, int threads);
+

--- a/src/sub_command.h
+++ b/src/sub_command.h
@@ -26,7 +26,8 @@ void append_clust_mst(string folder_path, string input_file, string output_file,
 void append_clust_greedy(string folder_path, string input_file, string output_file, bool sketch_by_file, int min_len, bool no_save, double threshold, int threads);
 
 void compute_kssd_sketches(vector<KssdSketchInfo>& sketches, KssdParameters& info, bool isSave, const string inputFile, string& folder_path, bool sketchByFile, const int minLen, const int kmerSize, const int drlevel, int threads);
-void compute_kssd_clusters(vector<KssdSketchInfo>& sketches, const KssdParameters info, bool sketchByFile, bool isContainment, const string folder_path, const string dictFile, const string indexFile, string outputFile, bool is_newick_tree, double threshold, bool isSave, int threads);
+void compute_kssd_clusters(vector<KssdSketchInfo>& sketches, const KssdParameters info, bool sketchByFile, bool isContainment, const string folder_path, string outputFile, bool is_newick_tree, double threshold, bool isSave, int threads);
 
 void clust_from_genome_fast(const string inputFile, string outputFile, string folder_path, bool is_newick_tree, bool sketchByFile, bool isContainment, const int kmerSize, const double threshold, const int drlevel, const int minLen, bool noSave, int threads);
+void clust_from_sketch_fast(string folder_path, string outputFile, bool is_newick_tree, bool isContainment, double threshold, int threads);
 

--- a/src/sub_command.h
+++ b/src/sub_command.h
@@ -16,6 +16,7 @@ void compute_clusters(vector<SketchInfo>& sketches, bool sketchByFile, string ou
 void clust_from_genomes(string inputFile, string outputFile, bool is_newick_tree, bool sketchByFile, int kmerSize, int sketchSize, double threshold, string sketchFunc, bool isContainment, int containCompress, int minLen, string folder_path, bool isSave, int threads);
 
 bool tune_parameters(bool sketchByFile, bool isSetKmer, string inputFile, int threads, int minLen, bool& isContainment, bool& isJaccard, int& kmerSize, double& threshold, int& containCompress, int& sketchSize);
+bool tune_kssd_parameters(bool sketchByFile, bool isSetKmer, string inputFile, int threads, int minLen, bool& isContainment, int& kmerSize, double& threshold, int &drlevel);
 
 void clust_from_sketches(string folder_path, string outputFile, bool is_newick_tree, double threshold, int threads);
 

--- a/src/sub_command.h
+++ b/src/sub_command.h
@@ -29,7 +29,7 @@ void append_clust_mst_fast(string folder_path, string input_file, string output_
 void append_clust_greedy(string folder_path, string input_file, string output_file, bool sketch_by_file, int min_len, bool no_save, double threshold, int threads);
 
 void compute_kssd_sketches(vector<KssdSketchInfo>& sketches, KssdParameters& info, bool isSave, const string inputFile, string& folder_path, bool sketchByFile, const int minLen, const int kmerSize, const int drlevel, int threads);
-void compute_kssd_clusters(vector<KssdSketchInfo>& sketches, const KssdParameters info, bool no_dense, bool sketchByFile, bool isContainment, const string folder_path, string outputFile, bool is_newick_tree, double threshold, bool isSave, int threads);
+void compute_kssd_clusters(vector<KssdSketchInfo>& sketches, const KssdParameters info, bool sketchByFile, bool no_dense, bool isContainment, const string folder_path, string outputFile, bool is_newick_tree, double threshold, bool isSave, int threads);
 
 void clust_from_genome_fast(const string inputFile, string outputFile, string folder_path, bool is_newick_tree, bool no_dense, bool sketchByFile, bool isContainment, const int kmerSize, const double threshold, const int drlevel, const int minLen, bool noSave, int threads);
 void clust_from_sketch_fast(string folder_path, string outputFile, bool is_newick_tree, bool no_dense, bool isContainment, double threshold, int threads);

--- a/src/sub_command.h
+++ b/src/sub_command.h
@@ -20,6 +20,7 @@ bool tune_parameters(bool sketchByFile, bool isSetKmer, string inputFile, int th
 void clust_from_sketches(string folder_path, string outputFile, bool is_newick_tree, double threshold, int threads);
 
 void clust_from_mst(string folder_path, string outputFile, bool is_newick_tree, double threshold, int threads);
+void clust_from_mst_fast(string folder_path, string outputFile, bool is_newick_tree, double threshold, int threads);
 
 void append_clust_mst(string folder_path, string input_file, string output_file, bool is_newick_tree, bool sketch_by_file, int min_len, bool no_save, double threshold, int threads);
 void append_clust_mst_fast(string folder_path, string input_file, string output_file, bool is_newick_tree, bool sketch_by_file, bool isContainment, int min_len, bool no_save, double threshold, int threads);

--- a/src/sub_command.h
+++ b/src/sub_command.h
@@ -22,6 +22,7 @@ void clust_from_sketches(string folder_path, string outputFile, bool is_newick_t
 void clust_from_mst(string folder_path, string outputFile, bool is_newick_tree, double threshold, int threads);
 
 void append_clust_mst(string folder_path, string input_file, string output_file, bool is_newick_tree, bool sketch_by_file, int min_len, bool no_save, double threshold, int threads);
+void append_clust_mst_fast(string folder_path, string input_file, string output_file, bool is_newick_tree, bool sketch_by_file, bool isContainment, int min_len, bool no_save, double threshold, int threads);
 
 void append_clust_greedy(string folder_path, string input_file, string output_file, bool sketch_by_file, int min_len, bool no_save, double threshold, int threads);
 

--- a/src/sub_command.h
+++ b/src/sub_command.h
@@ -11,19 +11,19 @@ using namespace std;
 
 void compute_sketches(vector<SketchInfo>& sketches, string inputFile, string& folder_path, bool sketchByFile, int minLen, int kmerSize, int sketchSize, string sketchFunc, bool isContainment, int containCompress, bool isSave, int threads);
 
-void compute_clusters(vector<SketchInfo>& sketches, bool sketchByFile, string outputFile, bool is_newick_tree, string folder_path, int sketch_func_id, double threshold, bool isSave, int threads);
+void compute_clusters(vector<SketchInfo>& sketches, bool sketchByFile, string outputFile, bool is_newick_tree, bool no_dense, string folder_path, int sketch_func_id, double threshold, bool isSave, int threads);
 
-void clust_from_genomes(string inputFile, string outputFile, bool is_newick_tree, bool sketchByFile, int kmerSize, int sketchSize, double threshold, string sketchFunc, bool isContainment, int containCompress, int minLen, string folder_path, bool isSave, int threads);
+void clust_from_genomes(string inputFile, string outputFile, bool is_newick_tree, bool sketchByFile, bool no_dense, int kmerSize, int sketchSize, double threshold, string sketchFunc, bool isContainment, int containCompress, int minLen, string folder_path, bool noSave, int threads);
 
 bool tune_parameters(bool sketchByFile, bool isSetKmer, string inputFile, int threads, int minLen, bool& isContainment, bool& isJaccard, int& kmerSize, double& threshold, int& containCompress, int& sketchSize);
 bool tune_kssd_parameters(bool sketchByFile, bool isSetKmer, string inputFile, int threads, int minLen, bool& isContainment, int& kmerSize, double& threshold, int &drlevel);
 
-void clust_from_sketches(string folder_path, string outputFile, bool is_newick_tree, double threshold, int threads);
+void clust_from_sketches(string folder_path, string outputFile, bool is_newick_tree, bool no_dense, double threshold, int threads);
 
-void clust_from_mst(string folder_path, string outputFile, bool is_newick_tree, double threshold, int threads);
+void clust_from_mst(string folder_path, string outputFile, bool is_newick_tree, bool no_dense, double threshold, int threads);
 void clust_from_mst_fast(string folder_path, string outputFile, bool is_newick_tree, bool no_dense, double threshold, int threads);
 
-void append_clust_mst(string folder_path, string input_file, string output_file, bool is_newick_tree, bool sketch_by_file, int min_len, bool no_save, double threshold, int threads);
+void append_clust_mst(string folder_path, string input_file, string output_file, bool is_newick_tree, bool no_dense, bool sketch_by_file, int min_len, bool no_save, double threshold, int threads);
 void append_clust_mst_fast(string folder_path, string input_file, string output_file, bool is_newick_tree, bool no_dense, bool sketch_by_file, bool isContainment, int min_len, bool no_save, double threshold, int threads);
 
 void append_clust_greedy(string folder_path, string input_file, string output_file, bool sketch_by_file, int min_len, bool no_save, double threshold, int threads);

--- a/src/sub_command.h
+++ b/src/sub_command.h
@@ -21,16 +21,16 @@ bool tune_kssd_parameters(bool sketchByFile, bool isSetKmer, string inputFile, i
 void clust_from_sketches(string folder_path, string outputFile, bool is_newick_tree, double threshold, int threads);
 
 void clust_from_mst(string folder_path, string outputFile, bool is_newick_tree, double threshold, int threads);
-void clust_from_mst_fast(string folder_path, string outputFile, bool is_newick_tree, double threshold, int threads);
+void clust_from_mst_fast(string folder_path, string outputFile, bool is_newick_tree, bool no_dense, double threshold, int threads);
 
 void append_clust_mst(string folder_path, string input_file, string output_file, bool is_newick_tree, bool sketch_by_file, int min_len, bool no_save, double threshold, int threads);
-void append_clust_mst_fast(string folder_path, string input_file, string output_file, bool is_newick_tree, bool sketch_by_file, bool isContainment, int min_len, bool no_save, double threshold, int threads);
+void append_clust_mst_fast(string folder_path, string input_file, string output_file, bool is_newick_tree, bool no_dense, bool sketch_by_file, bool isContainment, int min_len, bool no_save, double threshold, int threads);
 
 void append_clust_greedy(string folder_path, string input_file, string output_file, bool sketch_by_file, int min_len, bool no_save, double threshold, int threads);
 
 void compute_kssd_sketches(vector<KssdSketchInfo>& sketches, KssdParameters& info, bool isSave, const string inputFile, string& folder_path, bool sketchByFile, const int minLen, const int kmerSize, const int drlevel, int threads);
-void compute_kssd_clusters(vector<KssdSketchInfo>& sketches, const KssdParameters info, bool sketchByFile, bool isContainment, const string folder_path, string outputFile, bool is_newick_tree, double threshold, bool isSave, int threads);
+void compute_kssd_clusters(vector<KssdSketchInfo>& sketches, const KssdParameters info, bool no_dense, bool sketchByFile, bool isContainment, const string folder_path, string outputFile, bool is_newick_tree, double threshold, bool isSave, int threads);
 
-void clust_from_genome_fast(const string inputFile, string outputFile, string folder_path, bool is_newick_tree, bool sketchByFile, bool isContainment, const int kmerSize, const double threshold, const int drlevel, const int minLen, bool noSave, int threads);
-void clust_from_sketch_fast(string folder_path, string outputFile, bool is_newick_tree, bool isContainment, double threshold, int threads);
+void clust_from_genome_fast(const string inputFile, string outputFile, string folder_path, bool is_newick_tree, bool no_dense, bool sketchByFile, bool isContainment, const int kmerSize, const double threshold, const int drlevel, const int minLen, bool noSave, int threads);
+void clust_from_sketch_fast(string folder_path, string outputFile, bool is_newick_tree, bool no_dense, bool isContainment, double threshold, int threads);
 

--- a/version_history/history.md
+++ b/version_history/history.md
@@ -1,4 +1,9 @@
-# Latest version: `v.2.2.1` 
+# Latest version: `v.2.3.0` 
+* add `--fast` option for `clust-mst` to use the more efficient Kssd sketch strategy when computing the all-vs-all genome distances.
+    * The `--fast` option can work together with `--append`, `--presketched`, and `--premsted` options.
+    * the `--drlevel` is used for setting the dimention reduction level for Kssd sketches. Default value is 3, which is corresponding to a dimention reduction of $1 / 2^{(4*3)} = 1/4096$.
+
+## [`v.2.2.1`](v.2.2.1.md)
 * add `--newick-tree` option to output the Newick tree format for `clust-mst`.
 
 ## [`v.2.2.0`](v.2.2.0.md)

--- a/version_history/v.2.2.1.md
+++ b/version_history/v.2.2.1.md
@@ -1,12 +1,12 @@
 ![RabbitTClust](rabbittclust.png)
 
-# `RabbitTClust v.2.3.0`
+# `RabbitTClust v.2.2.1`
 RabbitTClust is a fast and memory-efficient genome clustering tool based on sketch-based distance estimations.
 It enables processing of large-scale datasets by combining dimensionality reduction techniques with streaming and parallelization on modern multi-core platforms.
 RabbitTClust supports classical single-linkage hierarchical (clust-mst) and greedy incremental clustering (clust-greedy) algorithms for different scenarios. 
 
 ## Installation
-`RabbitTClust v.2.3.0` can only support 64-bit Linux Systems.
+`RabbitTClust v.2.2.1` can only support 64-bit Linux Systems.
 
 The detailed update information for this version, as well as the version history, can be found in the [`version_history`](version_history/history.md) document.
 
@@ -41,7 +41,6 @@ Options:
   --presketched TEXT          clustering by the pre-generated sketch files rather than genomes
   --premsted TEXT             clustering by the pre-generated mst files rather than genomes for clust-mst
   --newick-tree               output the newick tree format file for clust-mst
-  --fast                      use the kssd algorithm for sketching and distance computing for clust-mst
   --append TEXT Excludes: --input
                               append genome file or file list with the pre-generated sketch or MST files
 
@@ -104,10 +103,6 @@ Options:
 # v.2.2.1 or later
 # output the newick tree format for clust-mst, use the --newick-tree flag.
 ./clust-mst -l -i bacteria.list --newick-tree -o bacteria.mst.clust 
-
-# v.2.3.0 or later
-# use the efficient Kssd sketch strategy for clust-mst, use the --fast flag.
-./clust-mst --fast -l -i bacteria.list -o bacteria.fast.mst.clust
 ```
 ## Output
 The output file is in a CD-HIT output format and is slightly different when running with or without `-l` input option.  


### PR DESCRIPTION
For computing the all-vs-all genome distances, We add the Kssd sketch strategy by using '--fast' option.
